### PR TITLE
[FIX] bug when using --exclude_patient_ratio 

### DIFF
--- a/ehr_ml/clmbr/__init__.py
+++ b/ehr_ml/clmbr/__init__.py
@@ -165,8 +165,8 @@ def create_info_program() -> None:
     else:
         assert args.exclude_patient_ratio is not None
         assert 0 < args.exclude_patient_ratio and args.exclude_patient_ratio < 1
-        train_pids = set(result["train_patient_ids_with_length"])
-        val_pids = set(result["val_patient_ids_with_length"])
+        train_pids = set([x[0] for x in result["train_patient_ids_with_length"]])
+        val_pids = set([x[0] for x in result["val_patient_ids_with_length"]])
         all_pids = train_pids.union(val_pids)
         excluded_pids = set(
             random.sample(


### PR DESCRIPTION
When running create_clmbr_info with the `--exclude_patient_ratio` parameter, I got the following error message: 

> TypeError: unhashable type: 'list' on line 168

This is because `result["train_patient_ids_with_length"] ` is a list of tuples (patient_ids, length). 

Taking the first element of each tuple in the list fixes the error:

> [x[0] for x in result["train_patient_ids_with_length"]]