### PR TITLE
Siyun/string description

### DIFF
--- a/ehr_ml/convert_timeline_to_json.py
+++ b/ehr_ml/convert_timeline_to_json.py
@@ -20,9 +20,9 @@ from .extension.ontology import (
 __all__ = ["ObservationWithValue", "TimelineReader", "Patient", "PatientDay"]
 
 
-def inspect_timeline_with_descriptions() -> None:
+def convert_patient_to_json() -> None:
     parser = argparse.ArgumentParser(
-        description="A tool for inspecting per-patient timeline with text descriptions for codes"
+        description="A tool for dumping per-patient timeline to json with text descriptions for codes"
     )
 
     parser.add_argument(
@@ -33,6 +33,10 @@ def inspect_timeline_with_descriptions() -> None:
 
     parser.add_argument(
         "patient_id", type=int, help="The patient id to inspect",
+    )
+
+    parser.add_argument(
+        "output_file", type=str, help="The name of the output file (.json will be appended automatically)"
     )
 
     args = parser.parse_args()
@@ -65,7 +69,7 @@ def inspect_timeline_with_descriptions() -> None:
 
     ontology = OntologyReader(os.path.join(args.extract_dir, "ontology.db"))
 
-    with open('test_patient.json', 'w', encoding='utf-8') as f:
+    with open(args.output_file+'.json', 'w', encoding='utf-8') as f:
         patient_timeline = {}
         patient_timeline['patient_id'] = patient_id
         patient_timeline['days'] = []

--- a/ehr_ml/create_timelines.py
+++ b/ehr_ml/create_timelines.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import argparse
+import bisect
+import json
+import os
+
+from .extension.timeline import (
+    ObservationWithValue,
+    TimelineReader,
+    Patient,
+    PatientDay,
+)
+
+from .extension.ontology import (
+    OntologyReader
+)
+
+__all__ = ["ObservationWithValue", "TimelineReader", "Patient", "PatientDay"]
+
+
+def create_patient_data() -> None:
+    parser = argparse.ArgumentParser(
+        description="A tool for inspecting an ehr_ml extract"
+    )
+
+    parser.add_argument(
+        "extract_dir",
+        type=str,
+        help="Path of the folder to the ehr_ml extraction",
+    )
+
+    parser.add_argument(
+        "patient_id", type=int, help="The patient id to inspect",
+    )
+
+    args = parser.parse_args()
+
+    source_file = os.path.join(args.extract_dir, "extract.db")
+    timelines = TimelineReader(source_file)
+    if args.patient_id is not None:
+        patient_id = int(args.patient_id)
+    else:
+        patient_id = timelines.get_patient_ids()[0]
+
+    location = bisect.bisect_left(timelines.get_patient_ids(), patient_id)
+    original_patient_id = timelines.get_original_patient_ids()[location]
+
+    if timelines.get_patient_ids()[location] != patient_id:
+        print("Could not locate patient ?", patient_id)
+        exit(-1)
+
+    patient = timelines.get_patient(patient_id)
+
+    print(f"Patient: {patient.patient_id}, (aka {original_patient_id})")
+
+    def obs_with_value_to_str(obs_with_value: ObservationWithValue) -> str:
+        code_text = timelines.get_dictionary().get_word(obs_with_value.code)
+        if obs_with_value.is_text:
+            value_text = timelines.get_value_dictionary().get_word(
+                obs_with_value.text_value
+            )
+            return f'{code_text}-"{value_text}"'
+        else:
+            return f"{code_text}-{obs_with_value.numeric_value}"
+
+    ontology = OntologyReader(os.path.join(args.extract_dir, "ontology.db"))
+
+    with open('test_patient.json', 'w', encoding='utf-8') as f:
+        patient_timeline = {}
+        for i, day in enumerate(patient.days):
+            patient_timeline[f'day {i}'] = {
+                "date": str(day.date),
+                "age in days": str(day.age),
+                "observation": {
+                    str(timelines.get_dictionary().get_word(a)) : str(ontology.get_text_description_dictionary().get_definition(a))
+                    for a in day.observations
+                },
+                "observation with values": sorted([
+                    obs_with_value_to_str(a) for a in day.observations_with_values]),
+            }
+
+        json.dump(patient_timeline, f, sort_keys=True, indent=4)

--- a/native/extract_extension.cpp
+++ b/native/extract_extension.cpp
@@ -171,11 +171,11 @@ void create_ontology(std::string_view root_path, std::string umls_path,
             subwords =
                 compute_subwords(*result, umls, aui_to_subwords_map,
                                  code_to_parents_map, ontology_dictionary);
-            auto res = umls.get_full_description(result);
+            auto res = umls.get_full_description(*result);
             if (res) {
                 aui_text_description_dictionary.add(
-                    word, absl::Substitute("$1/$2", res->first, res->second);
-                )
+                    word, absl::Substitute("$1/$2", res->first, res->second)
+                );
             } else {
                 aui_text_description_dictionary.add(word, "NO_NAME/NO_DEF");
             }

--- a/native/extract_extension.cpp
+++ b/native/extract_extension.cpp
@@ -166,18 +166,16 @@ void create_ontology(std::string_view root_path, std::string umls_path,
         if (result == std::nullopt) {
             subwords = {ontology_dictionary.map_or_add(
                 absl::Substitute("NO_MAP/$0", word))};
-            aui_text_description_dictionary.add(word, "NO_NAME/NO_DEF");
+            aui_text_description_dictionary.add(word, "NO_DEF");
         } else {
             subwords =
                 compute_subwords(*result, umls, aui_to_subwords_map,
                                  code_to_parents_map, ontology_dictionary);
-            auto res = umls.get_full_description(*result);
+            auto res = umls.get_definition(*result);
             if (res) {
-                aui_text_description_dictionary.add(
-                    word, absl::Substitute("$0/$1", res->first, res->second)
-                );
+                aui_text_description_dictionary.add(word, *res);
             } else {
-                aui_text_description_dictionary.add(word, "NO_NAME/NO_DEF");
+                aui_text_description_dictionary.add(word, "NO_DEF");
             }
         }
 

--- a/native/extract_extension.cpp
+++ b/native/extract_extension.cpp
@@ -174,7 +174,7 @@ void create_ontology(std::string_view root_path, std::string umls_path,
             auto res = umls.get_full_description(*result);
             if (res) {
                 aui_text_description_dictionary.add(
-                    word, absl::Substitute("$1/$2", res->first, res->second)
+                    word, absl::Substitute("$0/$1", res->first, res->second)
                 );
             } else {
                 aui_text_description_dictionary.add(word, "NO_NAME/NO_DEF");

--- a/native/ontology_extension.cpp
+++ b/native/ontology_extension.cpp
@@ -34,7 +34,7 @@ void register_ontology_extension(py::module& root) {
         .def("get_text_description_dictionary", &OntologyReader::get_text_description_dictionary,
              py::return_value_policy::reference_internal);
     py::class_<OntologyCodeDictionary>(m, "OntologyCodeDictionary")
-        .def("get_code_str", &OntologyCodeDictionary::get_code_str, py::arg("code"))
+        .def("get_word", &OntologyCodeDictionary::get_word, py::arg("code"))
         .def("get_definition", &OntologyCodeDictionary::get_definition, py::arg("code"))
         .def("map", &OntologyCodeDictionary::map, py::arg("code"));
 }

--- a/native/ontology_extension.cpp
+++ b/native/ontology_extension.cpp
@@ -33,4 +33,8 @@ void register_ontology_extension(py::module& root) {
              py::return_value_policy::reference_internal)
         .def("get_text_description_dictionary", &OntologyReader::get_text_description_dictionary,
              py::return_value_policy::reference_internal);
+    py::class_<OntologyCodeDictionary>(m, "OntologyCodeDictionary")
+        .def("get_code_str", &OntologyCodeDictionary::get_code_str, py::arg("code"))
+        .def("get_definition", &OntologyCodeDictionary::get_definition, py::arg("code"))
+        .def("map", &OntologyCodeDictionary::map, py::arg("code"));
 }

--- a/native/ontology_extension.cpp
+++ b/native/ontology_extension.cpp
@@ -30,7 +30,7 @@ void register_ontology_extension(py::module& root) {
         .def("get_recorded_date_codes",
              &OntologyReader::get_recorded_date_codes, py::keep_alive<0, 1>())
         .def("get_dictionary", &OntologyReader::get_dictionary,
-             py::return_value_policy::reference_internal);
+             py::return_value_policy::reference_internal)
         .def("get_text_description_dictionary", &OntologyReader::get_text_description_dictionary,
              py::return_value_policy::reference_internal);
 }

--- a/native/ontology_extension.cpp
+++ b/native/ontology_extension.cpp
@@ -31,4 +31,6 @@ void register_ontology_extension(py::module& root) {
              &OntologyReader::get_recorded_date_codes, py::keep_alive<0, 1>())
         .def("get_dictionary", &OntologyReader::get_dictionary,
              py::return_value_policy::reference_internal);
+        .def("get_text_description_dictionary", &OntologyReader::get_text_description_dictionary,
+             py::return_value_policy::reference_internal);
 }

--- a/native/reader.h
+++ b/native/reader.h
@@ -216,6 +216,124 @@ class TermDictionary {
     bool is_mutable;
 };
 
+class OntologyCodeDictionary {
+    public:
+        OntologyCodeDictionary();
+
+        OntologyCodeDictionary(const char* begin, size_t size) {
+            nlohmann::json result = nlohmann::json::parse(begin, begin + size);
+
+            text_description.resize(result["descr"].size());
+
+            for (const auto& entry : result["descr"]) {
+                std::string code_str = entry[0].get<std::string>();
+                StringHolder code(code_str);
+                code.make_copy();
+
+                uint32_t index = entry[1];
+                std::string definition = entry[2].get<std::string>();
+                map_to_index.emplace(code, index);
+
+                if (index >= text_description.size()) {
+                    std::cout << "Text descriptions are not contiguous? " 
+                            << index << " " << text_description.size() << std::endl;
+                    abort();
+                }
+
+                text_description[index] = std::make_pair(code_str, definition);
+            }
+        }
+
+        OntologyCodeDictionary(std::vector<std::pair<std::string, std::string>> descr) 
+            : text_description(std::move(descr)) {
+            if (text_description.size() > std::numeric_limits<uint32_t>::max()) {
+                std::cout << "Creating a dictionary that's too large "
+                        << text_description.size() << std::endl;
+                abort();
+            }
+
+            for (size_t i = 0; i < text_description.size(); i++) {
+                StringHolder code(text_description[i].first);
+                code.make_copy();
+
+                map_to_index.emplace(code, i);
+            }
+        }
+
+        uint32_t add(std::string_view code, std::string_view definition) {
+            auto [iter, added] =
+                map_to_index.emplace(StringHolder(code), text_description.size());
+
+            if (added) {
+                text_description.push_back(std::make_pair(std::string(code), std::string(definition)));
+                iter->first.make_copy();
+
+                if (text_description.size() > std::numeric_limits<uint32_t>::max()) {
+                    std::cout << "Adding a word to a dictionary that is too large "
+                            << text_description.size() << std::endl;
+                    abort();
+                }
+            } else {
+                std::cout << "Got duplicate definition for code_str " << code 
+                          << "Existing: " << text_description[iter->second].second
+                          << "New: " << definition << std::endl;
+                abort();
+            }
+            return iter->second;
+        }
+
+        std::optional<uint32_t> map(std::string_view code) const {
+            auto iter = map_to_index.find(StringHolder(code));
+
+            if (iter == std::end(map_to_index)) {
+                return {};
+            } else {
+                return {iter->second};
+            }
+        }
+
+        std::optional<std::string_view> get_code_str(uint32_t idx) const {
+            if (idx >= text_description.size()) {
+                return {};
+            } else {
+                return {text_description[idx].first};
+            }
+        }
+
+        std::optional<std::string_view> get_definition(uint32_t idx) const {
+            if (idx >= text_description.size()) {
+                return {};
+            } else {
+                return {text_description[idx].second};
+            }
+        }
+
+        void clear() {
+            map_to_index.clear();
+            text_description.clear();
+        }
+
+        std::string to_json() const {
+            std::vector<std::tuple<std::string, uint32_t, std::string>> entries;
+
+            for (size_t i = 0; i < text_description.size(); i++) {
+                const auto& entry = text_description[i];
+                entries.push_back(std::make_tuple(entry.first, i, entry.second));
+            }
+
+            nlohmann::json result;
+            result["descr"] = entries;
+
+            return result.dump();
+        }
+
+        uint32_t size() const { return text_description.size(); }
+
+    private:
+        absl::flat_hash_map<StringHolder, uint32_t> map_to_index;
+        std::vector<std::tuple<std::string, std::string>> text_description;
+};
+
 template <class To, class From>
 typename std::enable_if<
     (sizeof(To) == sizeof(From)) && std::is_trivially_copyable<From>::value &&
@@ -526,6 +644,15 @@ class OntologyReader {
         return recorded_date_codes;
     }
 
+    const OntologyCodeDictionary& get_text_description_dictionary() {
+        if (!text_description_dictionary) {
+            auto [dict_start, dict_size] = reader.get_str("text_description_dictionary");
+            text_description_dictionary = OntologyCodeDictionary(dict_start, dict_size);
+        }
+
+        return *text_description_dictionary;
+    }
+
     uint32_t get_root_code() const { return root_code; }
 
    private:
@@ -557,6 +684,8 @@ class OntologyReader {
     ConstdbReader reader;
 
     std::optional<TermDictionary> dictionary;
+
+    std::optional<OntologyCodeDictionary> text_description_dictionary;
 
     std::optional<absl::flat_hash_map<uint32_t, std::vector<uint32_t>>>
         inverse_map;

--- a/native/reader.h
+++ b/native/reader.h
@@ -260,6 +260,9 @@ class OntologyCodeDictionary {
             }
         }
 
+        OntologyCodeDictionary(const OntologyCodeDictionary& source)
+            : OntologyCodeDictionary(source.text_description) {}
+
         uint32_t add(std::string_view code, std::string_view definition) {
             auto [iter, added] =
                 map_to_index.emplace(StringHolder(code), text_description.size());
@@ -331,7 +334,7 @@ class OntologyCodeDictionary {
 
     private:
         absl::flat_hash_map<StringHolder, uint32_t> map_to_index;
-        std::vector<std::tuple<std::string, std::string>> text_description;
+        std::vector<std::pair<std::string, std::string>> text_description;
 };
 
 template <class To, class From>

--- a/native/reader.h
+++ b/native/reader.h
@@ -218,7 +218,7 @@ class TermDictionary {
 
 class OntologyCodeDictionary {
     public:
-        OntologyCodeDictionary();
+        OntologyCodeDictionary(){};
 
         OntologyCodeDictionary(const char* begin, size_t size) {
             nlohmann::json result = nlohmann::json::parse(begin, begin + size);
@@ -542,17 +542,17 @@ class ExtractReader {
 class OntologyReader {
    public:
     OntologyReader(const char* path) : reader(path, false) {
-        for (uint32_t subword = 0; subword < get_dictionary().size();
-             subword++) {
-            for (uint32_t parent : get_parents(subword)) {
-                children_map[parent].push_back(subword);
-            }
-        }
+        // for (uint32_t subword = 0; subword < get_dictionary().size();
+        //      subword++) {
+        //     for (uint32_t parent : get_parents(subword)) {
+        //         children_map[parent].push_back(subword);
+        //     }
+        // }
 
-        for (auto& item : children_map) {
-            std::sort(std::begin(item.second), std::end(item.second));
-        }
-
+        // for (auto& item : children_map) {
+        //     std::sort(std::begin(item.second), std::end(item.second));
+        // }
+        std::cout << "Entering Ontology Reader" << std::endl;
         auto [ptr, size] = reader.get_str("root");
         if (size != sizeof(uint32_t)) {
             std::cout << "Could not find the root code " << std::endl;
@@ -650,6 +650,7 @@ class OntologyReader {
     const OntologyCodeDictionary& get_text_description_dictionary() {
         if (!text_description_dictionary) {
             auto [dict_start, dict_size] = reader.get_str("text_description_dictionary");
+            std::cout << "Got test description dictionary of size " << dict_size << std::endl;
             text_description_dictionary = OntologyCodeDictionary(dict_start, dict_size);
         }
 

--- a/native/reader.h
+++ b/native/reader.h
@@ -542,17 +542,16 @@ class ExtractReader {
 class OntologyReader {
    public:
     OntologyReader(const char* path) : reader(path, false) {
-        // for (uint32_t subword = 0; subword < get_dictionary().size();
-        //      subword++) {
-        //     for (uint32_t parent : get_parents(subword)) {
-        //         children_map[parent].push_back(subword);
-        //     }
-        // }
+        for (uint32_t subword = 0; subword < get_dictionary().size();
+             subword++) {
+            for (uint32_t parent : get_parents(subword)) {
+                children_map[parent].push_back(subword);
+            }
+        }
 
-        // for (auto& item : children_map) {
-        //     std::sort(std::begin(item.second), std::end(item.second));
-        // }
-        std::cout << "Entering Ontology Reader" << std::endl;
+        for (auto& item : children_map) {
+            std::sort(std::begin(item.second), std::end(item.second));
+        }
         auto [ptr, size] = reader.get_str("root");
         if (size != sizeof(uint32_t)) {
             std::cout << "Could not find the root code " << std::endl;

--- a/native/umls.h
+++ b/native/umls.h
@@ -20,7 +20,7 @@ class UMLS {
             load_aui_to_parents_map(umls_path, aui_to_code_map);
 
         aui_to_text_description_map = 
-            aui_to_text_description_map(umls_path, aui_to_code_map);
+            aui_to_description_map(umls_path, aui_to_code_map);
     }
 
     std::optional<std::string> get_aui(const std::string& sab,
@@ -285,7 +285,7 @@ class UMLS {
     }
 
     absl::flat_hash_map<std::string, std::pair<std::string, std::string>>
-    aui_to_text_description_map(
+    aui_to_description_map(
         std::string umls_path,
         const absl::flat_hash_map<std::string,
                                   std::pair<std::string, std::string>>&
@@ -298,7 +298,7 @@ class UMLS {
 
         std::ifstream infile(mrconso);
 
-        absl::flat_hash_map<std::string, std::string> result;
+        absl::flat_hash_map<std::string, std::pair<std::string, std::string>> result;
 
         std::string line;
         std::string definition;
@@ -324,7 +324,7 @@ class UMLS {
             if (!added) {
                 std::cout << "Got duplicate text description for aui " << aui 
                           << "Existing: (" << iter->second.first << ": " << iter->second.second << ") "
-                          << "New: (" << def << ": " << definition << ")" << std::endl;
+                          << "New: (" << name << ": " << definition << ")" << std::endl;
                 abort();
             }
         }

--- a/native/umls.h
+++ b/native/umls.h
@@ -236,11 +236,6 @@ class UMLS {
                                     std::string>&
             code_to_aui_map) {
 
-        // // auto aui_to_definition_map = load_aui_to_definition_map(umls_path, aui_to_code_map);
-        // absl::flat_hash_map<std::string, std::string> aui_to_definition_map;
-        // aui_to_definition_map.insert(std::make_pair(std::string("A17825389"), std::string("subclass of diabetes mellitus that is not insulin responsive or dependent; characterized initially by insulin resistance and hyperinsulinemia and eventually by glucose intolerance, hyperglycemia, and overt diabetes; type II diabetes mellitus is no longer considered a disease exclusively found in adults; patients seldom develop ketosis but often exhibit obesity")));
-        // // C0011860|A0484862|AT51220383||CSP|subclass of diabetes mellitus that is not insulin responsive or dependent; characterized initially by insulin resistance and hyperinsulinemia and eventually by glucose intolerance, hyperglycemia, and overt diabetes; type II diabetes mellitus is no longer considered a disease exclusively found in adults; patients seldom develop ketosis but often exhibit obesity.|N||
-
         std::string mrconso =
             absl::Substitute("$0/$1", umls_path, "MRCONSO.RRF");
 
@@ -265,7 +260,7 @@ class UMLS {
                 continue;
             }
 
-            if (suppress != "O" && suppress != "Y") {
+            if (suppress == "O" || suppress == "Y") {
                 continue;
             }
 
@@ -280,7 +275,7 @@ class UMLS {
                 continue;
             }
 
-            auto [iter, added] = result.insert(std::make_pair(aui, name));
+            auto [iter, added] = result.insert(std::make_pair(find_aui->second, name));
             if (!added) {
                 std::string prev_name = iter->second;
                 if (prev_name.size() <= name.size()) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ clmbr_train_model = "ehr_ml.clmbr:train_model"
 clmbr_debug_model = "ehr_ml.clmbr:debug_model"
 patient2vec_train_model = 'ehr_ml.patient2vec:train_model'
 patient2vec_debug_model = 'ehr_ml.patient2vec:debug_model'
+create_patient_data = "ehr_ml.create_timelines:create_patient_data"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ clmbr_train_model = "ehr_ml.clmbr:train_model"
 clmbr_debug_model = "ehr_ml.clmbr:debug_model"
 patient2vec_train_model = 'ehr_ml.patient2vec:train_model'
 patient2vec_debug_model = 'ehr_ml.patient2vec:debug_model'
-inspect_patient_timeline = 'ehr_ml.convert_timeline_to_json:inspect_timeline_with_descriptions'
+convert_patient_to_json = 'ehr_ml.convert_timeline_to_json:convert_patient_to_json'
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ clmbr_train_model = "ehr_ml.clmbr:train_model"
 clmbr_debug_model = "ehr_ml.clmbr:debug_model"
 patient2vec_train_model = 'ehr_ml.patient2vec:train_model'
 patient2vec_debug_model = 'ehr_ml.patient2vec:debug_model'
-create_patient_data = "ehr_ml.create_timelines:create_patient_data"
+inspect_patient_timeline = 'ehr_ml.convert_timeline_to_json:inspect_timeline_with_descriptions'
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/test_patient.json
+++ b/test_patient.json
@@ -1,909 +1,2078 @@
 {
-    "day 0": {
-        "age in days": "0",
-        "date": "1943-01-01",
-        "observation": {
-            "Ethnicity/Not Hispanic": "NO_DEF",
-            "Gender/M": "NO_DEF",
-            "Race/5": "NO_DEF"
+    "days": [
+        {
+            "age in days": "0",
+            "date": "1922-01-01",
+            "observation": {
+                "Ethnicity/Not Hispanic": "NO_DEF",
+                "Gender/M": "NO_DEF",
+                "Race/5": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 1": {
-        "age in days": "24018",
-        "date": "2008-10-04",
-        "observation": {
-            "CPT4/29405": "Application of below knee to toes cast",
-            "CPT4/83036": "HEMOGLOBIN GLYCOSYLATED A1C",
-            "ICD10CM/G57.90": "Unspecified mononeuropathy of unspecified lower limb",
-            "ICD10CM/S82.839B": "Other fracture of upper and lower end of unspecified fibula, initial encounter for open fracture type I or II",
-            "ICD10CM/S92.403A": "NO_DEF",
-            "ICD10CM/Z23": "Encounter for immunization"
+        {
+            "age in days": "31515",
+            "date": "2008-04-14",
+            "observation": {
+                "CPT4/77280": "THER RAD SIMULAJ-AIDED FIELD SETTING SIMPLE",
+                "CPT4/93000": "ECG ROUTINE ECG W/LEAST 12 LDS W/I&R",
+                "CPT4/94060": "BRNCDILAT RSPSE SPMTRY PRE&POST-BRNCDILAT ADMN",
+                "HCPCS/G8443": "NO_DEF",
+                "ICD10CM/C82.91": "Follicular lymphoma, unspecified, lymph nodes of head, face, and neck",
+                "ICD10CM/C83.73": "Burkitt lymphoma, intra-abdominal lymph nodes"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 10": {
-        "age in days": "24123",
-        "date": "2009-01-17",
-        "observation": {
-            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
-            "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
-            "ICD10CM/R07.2": "NO_DEF",
-            "ICD10CM/Z23": "Encounter for immunization",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31523",
+            "date": "2008-04-22",
+            "observation": {
+                "CPT4/11100": "NO_DEF",
+                "ICD10CM/D37.8": "Neoplasm of uncertain behavior of anus NOS",
+                "ICD10CM/D48.5": "Neoplasm of uncertain behavior of anal skin"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 11": {
-        "age in days": "24133",
-        "date": "2009-01-27",
-        "observation": {
-            "ATC/D01AE54": "undecylenic acid, combinations",
-            "ATC/D07XA01": "NO_DEF",
-            "ATC/D07XA02": "NO_DEF",
-            "ATC/D07XB05": "NO_DEF",
-            "ATC/D08AC52": "chlorhexidine, combinations",
-            "ATC/D08AX05": "isopropanol",
-            "ATC/D08AX53": "propanol, combinations",
-            "ATC/S02AA30": "NO_DEF",
-            "ATC/S03AA30": "antiinfectives, combinations"
+        {
+            "age in days": "31524",
+            "date": "2008-04-23",
+            "observation": {
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "CPT4/85007": "BLOOD COUNT SMEAR MCRSCP W/MNL DIFRNTL WBC COUNT",
+                "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
         },
-        "observation with values": []
-    },
-    "day 12": {
-        "age in days": "24135",
-        "date": "2009-01-29",
-        "observation": {
-            "ATC/N07AA51": "neostigmine, combinations",
-            "ATC/N07AX01": "NO_DEF",
-            "ATC/R01BA53": "NO_DEF",
-            "ATC/S01EA51": "epinephrine, combinations",
-            "ATC/S01EB01": "NO_DEF",
-            "ATC/S01EB51": "pilocarpine, combinations",
-            "ATC/S01ED51": "timolol, combinations",
-            "ATC/S01ED52": "betaxolol, combinations",
-            "ATC/S01GA51": "naphazoline, combinations",
-            "ATC/S01KA51": "hyaluronic acid, combinations"
+        {
+            "age in days": "31542",
+            "date": "2008-05-11",
+            "observation": {
+                "CPT4/83036": "HEMOGLOBIN GLYCOSYLATED A1C",
+                "CPT4/92014": "OPHTH MEDICAL XM&EVAL COMPRHNSV ESTAB PT 1/>",
+                "CPT4/92015": "DETERMINATION REFRACTIVE STATE",
+                "CPT4/97530": "THERAPEUT ACTVITY DIRECT PT CONTACT EACH 15 MIN",
+                "ICD10CM/H04.129": "Dry eye syndrome of unspecified lacrimal gland",
+                "ICD10CM/H40.1110": "Primary open-angle glaucoma, right eye, stage unspecified",
+                "ICD10CM/H52.4": "NO_DEF",
+                "ICD10CM/M12.9": "NO_DEF",
+                "ICD10CM/M25.579": "Pain in unspecified ankle and joints of unspecified foot",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 13": {
-        "age in days": "24173",
-        "date": "2009-03-08",
-        "observation": {
-            "CPT4/99254": "INITIAL INPATIENT CONSULT NEW/ESTAB PT 80 MIN",
-            "ICD10CM/R11.0": "Nausea NOS",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31543",
+            "date": "2008-05-12",
+            "observation": {
+                "CPT4/3074F": "MOST RECENT SYSTOLIC BLOOD PRESSURE <130 MM HG",
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "CPT4/80053": "Measurement of albumin",
+                "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 14": {
-        "age in days": "24179",
-        "date": "2009-03-14",
-        "observation": {
-            "CPT4/72194": "CT PELVIS W/O & W/CONTRAST MATERIAL",
-            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
-            "ICD10CM/R10.9": "Unspecified abdominal pain"
+        {
+            "age in days": "31550",
+            "date": "2008-05-19",
+            "observation": {
+                "CPT4/72020": "X-ray of spine, 1 view",
+                "CPT4/80053": "Measurement of albumin",
+                "CPT4/85025": "Automated platelet count",
+                "CPT4/98941": "CHIROPRACTIC MANIPULATIVE TX SPINAL 3-4 REGIONS",
+                "ICD10CM/M47.812": "Spondylosis without myelopathy or radiculopathy, cervical region",
+                "ICD10CM/M48.10": "NO_DEF",
+                "ICD10CM/M50.20": "Other cervical disc displacement, unspecified cervical region",
+                "ICD10CM/M50.30": "Other cervical disc degeneration, unspecified cervical region",
+                "ICD10CM/Z12.5": "Encounter for screening for malignant neoplasm of prostate",
+                "ICD10CM/Z13.228": "Encounter for screening for other metabolic disorders"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 15": {
-        "age in days": "24189",
-        "date": "2009-03-24",
-        "observation": {
-            "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
-            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
-            "ICD10CM/D56.8": "Mixed thalassemia",
-            "ICD10CM/D63.8": "NO_DEF"
+        {
+            "age in days": "31571",
+            "date": "2008-06-09",
+            "observation": {
+                "CPT4/80053": "Measurement of albumin",
+                "CPT4/80061": "LIPID PANEL",
+                "CPT4/82947": "Blood glucose (sugar) level",
+                "HCPCS/P9603": "Travel allowance one way in connection with medically necessary laboratory specimen collection drawn from home bound or nursing home bound patient; prorated miles actually travelled",
+                "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+                "ICD10CM/E78.00": "(Pure) hypercholesterolemia NOS",
+                "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 16": {
-        "age in days": "24195",
-        "date": "2009-03-30",
-        "observation": {
-            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
-            "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
-            "ICD10CM/I63.50": "Cerebral infarction due to unspecified occlusion or stenosis of unspecified cerebral artery",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31572",
+            "date": "2008-06-10",
+            "observation": {
+                "CPT4/85018": "BLOOD COUNT HEMOGLOBIN",
+                "ICD10CM/G93.3": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 17": {
-        "age in days": "24197",
-        "date": "2009-04-01",
-        "observation": {
-            "ATC/C03AX01": "hydrochlorothiazide, combinations",
-            "ATC/C09AA03": "NO_DEF",
-            "ATC/C09BA03": "lisinopril and diuretics",
-            "ATC/C09BB03": "lisinopril and amlodipine",
-            "ATC/C10BX07": "rosuvastatin, amlodipine and lisinopril"
+        {
+            "age in days": "31580",
+            "date": "2008-06-18",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/S43.429A": "Sprain of unspecified rotator cuff capsule, initial encounter"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 18": {
-        "age in days": "24208",
-        "date": "2009-04-12",
-        "observation": {
-            "ICD10CM/C78.00": "Secondary malignant neoplasm of unspecified lung",
-            "ICD10CM/C79.89": "NO_DEF",
-            "ICD10CM/E87.6": "Potassium [K] deficiency",
-            "ICD10CM/M15.9": "Generalized osteoarthritis NOS",
-            "ICD10CM/N18.3": "Chronic kidney disease, stage 3 (moderate)",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31584",
+            "date": "2008-06-22",
+            "observation": {
+                "CPT4/28090": "Excision of cyst of tendon of foot",
+                "ICD10CM/M67.40": "Ganglion, unspecified site",
+                "ICD10CM/M77.50": "Other enthesopathy of unspecified foot and ankle"
+            },
+            "observation with values": {}
         },
-        "observation with values": [
-            "Visit/IP-6.0"
-        ]
-    },
-    "day 19": {
-        "age in days": "24211",
-        "date": "2009-04-15",
-        "observation": {
-            "CPT4/88175": "Cytopathology on vaginal specimen",
-            "CPT4/99215": "OFFICE OUTPATIENT VISIT 40 MINUTES",
-            "ICD10CM/E03.9": "Myxedema NOS",
-            "ICD10CM/E78.00": "(Pure) hypercholesterolemia NOS",
-            "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
-            "ICD10CM/Z12.4": "Encounter for screening pap smear for malignant neoplasm of cervix",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31585",
+            "date": "2008-06-23",
+            "observation": {
+                "CPT4/99284": "EMERGENCY DEPARTMENT VISIT HIGH/URGENT SEVERITY",
+                "ICD10CM/E08.65": "Diabetes mellitus due to underlying condition with hyperglycemia",
+                "ICD10CM/E09.69": "Drug or chemical induced diabetes mellitus with other specified complication",
+                "ICD10CM/E11.618": "Type 2 diabetes mellitus with other diabetic arthropathy"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 2": {
-        "age in days": "24022",
-        "date": "2008-10-08",
-        "observation": {
-            "CPT4/71010": "NO_DEF",
-            "CPT4/76700": "Ultrasound of abdomen",
-            "ICD10CM/I10": "hypertension (arterial) (benign) (essential) (malignant) (primary) (systemic)",
-            "ICD10CM/R10.10": "Upper abdominal pain, unspecified",
-            "ICD10CM/R10.813": "Right lower quadrant abdominal tenderness",
-            "ICD10CM/R10.9": "Unspecified abdominal pain",
-            "ICD10CM/R11.2": "Nausea with vomiting, unspecified"
+        {
+            "age in days": "31592",
+            "date": "2008-06-30",
+            "observation": {
+                "CPT4/82306": "Vitamin D-3 level",
+                "ICD10CM/G25.89": "NO_DEF",
+                "ICD10CM/K20.9": "NO_DEF",
+                "ICD10CM/K21.9": "Esophageal reflux NOS",
+                "ICD10CM/K52.29": "Immediate gastrointestinal hypersensitivity"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 20": {
-        "age in days": "24237",
-        "date": "2009-05-11",
-        "observation": {
-            "CPT4/99222": "INITIAL HOSPITAL CARE/DAY 50 MINUTES",
-            "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
-            "ICD10CM/I62.9": "Nontraumatic intracranial hemorrhage, unspecified",
-            "ICD10CM/N18.9": "Chronic uremia NOS",
-            "ICD10CM/Z49.01": "Toilet or cleansing of renal dialysis catheter",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31600",
+            "date": "2008-07-08",
+            "observation": {
+                "CPT4/97001": "NO_DEF",
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "ICD10CM/M25.439": "Effusion, unspecified wrist",
+                "ICD10CM/M62.40": "Contracture of muscle, unspecified site",
+                "ICD10CM/R26.2": "NO_DEF",
+                "ICD10CM/Z96.649": "Presence of unspecified artificial hip joint",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 21": {
-        "age in days": "24242",
-        "date": "2009-05-16",
-        "observation": {
-            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
-            "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
-            "ICD10CM/N18.9": "Chronic uremia NOS",
-            "ICD10CM/Z49.32": "Encounter for peritoneal equilibration test",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31606",
+            "date": "2008-07-14",
+            "observation": {
+                "CPT4/97035": "Application of ultrasound modality",
+                "ICD10CM/M47.817": "Spondylosis without myelopathy or radiculopathy, lumbosacral region",
+                "ICD10CM/M48.08": "NO_DEF",
+                "ICD10CM/M54.14": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 22": {
-        "age in days": "24259",
-        "date": "2009-06-02",
-        "observation": {
-            "CPT4/80048": "Measurement of creatinine",
-            "CPT4/80061": "LIPID PANEL",
-            "CPT4/80076": "HEPATIC FUNCTION PANEL",
-            "CPT4/82306": "Vitamin D-3 level",
-            "CPT4/84075": "Phosphatase, alkaline",
-            "CPT4/85025": "Automated platelet count",
-            "CPT4/85610": "PROTHROMBIN TIME",
-            "CPT4/87088": "Bacterial urine culture",
-            "CPT4/96372": "Subcutaneous diagnostic injection",
-            "ICD10CM/F73": "IQ level below 20-25",
-            "ICD10CM/I48.91": "Unspecified atrial fibrillation",
-            "ICD10CM/Z48.02": "Encounter for removal of sutures",
-            "ICD10CM/Z79.01": "Long term (current) use of anticoagulants",
-            "ICD10CM/Z79.84": "Long term (current) use of oral hypoglycemic drugs",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31610",
+            "date": "2008-07-18",
+            "observation": {
+                "CPT4/29824": "ARTHROSCOPY SHOULDER DISTAL CLAVICULECTOMY",
+                "HCPCS/G0283": "Electrical stimulation (unattended), to one or more areas for indication(s) other than wound care, as part of a therapy plan of care",
+                "ICD10CM/M16.9": "Osteoarthritis of hip, unspecified",
+                "ICD10CM/M19.019": "Primary osteoarthritis, unspecified shoulder",
+                "ICD10CM/M24.019": "Loose body in unspecified shoulder",
+                "ICD10CM/M62.81": "Muscle weakness (generalized)"
+            },
+            "observation with values": {}
         },
-        "observation with values": [
-            "Visit/OP-0.0"
-        ]
-    },
-    "day 23": {
-        "age in days": "24262",
-        "date": "2009-06-05",
-        "observation": {
-            "CPT4/99284": "EMERGENCY DEPARTMENT VISIT HIGH/URGENT SEVERITY",
-            "ICD10CM/M46.1": "NO_DEF",
-            "ICD10CM/M50.30": "Other cervical disc degeneration, unspecified cervical region",
-            "ICD10CM/M54.5": "Lumbago NOS",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31616",
+            "date": "2008-07-24",
+            "observation": {
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "ICD10CM/M46.1": "NO_DEF",
+                "ICD10CM/M53.0": "NO_DEF"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
         },
-        "observation with values": []
-    },
-    "day 24": {
-        "age in days": "24278",
-        "date": "2009-06-21",
-        "observation": {
-            "CPT4/90862": "NO_DEF",
-            "ICD10CM/F20.0": "NO_DEF",
-            "ICD10CM/F20.2": "Schizophrenic catalepsy"
+        {
+            "age in days": "31619",
+            "date": "2008-07-27",
+            "observation": {
+                "CPT4/80048": "Measurement of creatinine",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/E11.65": "Type 2 diabetes mellitus with hyperglycemia",
+                "ICD10CM/E13.10": "Other specified diabetes mellitus with ketoacidosis without coma",
+                "ICD10CM/Z79.4": "Long term (current) use of insulin"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
         },
-        "observation with values": []
-    },
-    "day 25": {
-        "age in days": "24280",
-        "date": "2009-06-23",
-        "observation": {
-            "CPT4/71101": "RADEX RIBS UNI W/POSTEROANT CH MINIMUM 3 VIEWS",
-            "CPT4/78480": "NO_DEF",
-            "CPT4/94060": "BRNCDILAT RSPSE SPMTRY PRE&POST-BRNCDILAT ADMN",
-            "ICD10CM/S69.80XA": "Other specified injuries of unspecified wrist, hand and finger(s), initial encounter",
-            "ICD10CM/W22.09XA": "Striking against other stationary object, initial encounter",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31621",
+            "date": "2008-07-29",
+            "observation": {
+                "CPT4/82570": "CREATININE OTHER SOURCE",
+                "CPT4/85025": "Automated platelet count",
+                "ICD10CM/C75.0": "NO_DEF",
+                "ICD10CM/D63.0": "NO_DEF",
+                "ICD10CM/D64.9": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": [
-            "Visit/OP-0.0"
-        ]
-    },
-    "day 26": {
-        "age in days": "24283",
-        "date": "2009-06-26",
-        "observation": {
-            "ATC/G04CA03": "NO_DEF"
+        {
+            "age in days": "31628",
+            "date": "2008-08-05",
+            "observation": {
+                "CPT4/72158": "MRI SPINAL CANAL LUMBAR W/O & W/CONTR MATRL",
+                "ICD10CM/M51.26": "Other intervertebral disc displacement, lumbar region",
+                "ICD10CM/M51.9": "Unspecified thoracic, thoracolumbar and lumbosacral intervertebral disc disorder",
+                "ICD10CM/M96.1": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 27": {
-        "age in days": "24290",
-        "date": "2009-07-03",
-        "observation": {
-            "CPT4/77280": "THER RAD SIMULAJ-AIDED FIELD SETTING SIMPLE",
-            "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
-            "HCPCS/G8447": "NO_DEF",
-            "ICD10CM/I47.2": "NO_DEF",
-            "ICD10CM/I49.9": "Arrhythmia (cardiac) NOS",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31629",
+            "date": "2008-08-06",
+            "observation": {
+                "CPT4/23415": "Release of coracoacromial ligament",
+                "CPT4/4048F": "DOC ANTIBIO GIVEN W/IN 1 HR PRIOR SURG/INCIS",
+                "ICD10CM/M54.5": "Lumbago NOS",
+                "ICD10CM/M75.30": "Calcific tendinitis of unspecified shoulder",
+                "ICD10CM/M79.A3": "Nontraumatic compartment syndrome of abdomen"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 28": {
-        "age in days": "24303",
-        "date": "2009-07-16",
-        "observation": {
-            "HCPCS/A0427": "Ambulance service, advanced life support, emergency transport, level 1 (als 1 - emergency)",
-            "ICD10CM/K85.90": "Acute pancreatitis without necrosis or infection, unspecified",
-            "ICD10CM/R10.815": "Periumbilic abdominal tenderness",
-            "ICD10CM/R10.84": "NO_DEF",
-            "ICD10CM/R11.10": "Vomiting, unspecified",
-            "ICD10CM/R63.4": "NO_DEF"
+        {
+            "age in days": "31632",
+            "date": "2008-08-09",
+            "observation": {
+                "CPT4/29826": "Shaving of shoulder bone using an endoscope",
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "ICD10CM/M15.0": "Primary generalized (osteo)arthritis",
+                "ICD10CM/M19.90": "Unspecified osteoarthritis, unspecified site",
+                "ICD10CM/M24.019": "Loose body in unspecified shoulder",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 29": {
-        "age in days": "24318",
-        "date": "2009-07-31",
-        "observation": {
-            "CPT4/80048": "Measurement of creatinine",
-            "CPT4/80053": "Measurement of albumin",
-            "CPT4/80061": "LIPID PANEL",
-            "CPT4/83036": "HEMOGLOBIN GLYCOSYLATED A1C",
-            "CPT4/84439": "Thyroxine; free",
-            "CPT4/84443": "Thyroid stimulating hormone (TSH)",
-            "CPT4/84460": "Liver enzyme (SGPT), level",
-            "CPT4/85025": "Automated platelet count",
-            "HCPCS/G0103": "Prostate cancer screening; prostate specific antigen test (psa)",
-            "ICD10CM/E07.9": "NO_DEF",
-            "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
-            "ICD10CM/E67.8": "NO_DEF",
-            "ICD10CM/I49.3": "NO_DEF",
-            "ICD10CM/R39.12": "Weak urinary steam",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31633",
+            "date": "2008-08-10",
+            "observation": {
+                "CPT4/99309": "SBSQ NURSING FACIL CARE/DAY NEW PROBLEM 25 MIN",
+                "ICD10CM/E16.2": "NO_DEF",
+                "ICD10CM/E22.8": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 3": {
-        "age in days": "24023",
-        "date": "2008-10-09",
-        "observation": {
-            "CPT4/20610": "Injection of major joint",
-            "CPT4/71020": "NO_DEF",
-            "CPT4/76514": "OPHTHALMIC US DX CORNEAL PACHYMETRY UNI/BI",
-            "CPT4/85025": "Automated platelet count",
-            "CPT4/96372": "Subcutaneous diagnostic injection",
-            "CPT4/99000": "HANDLG&/OR CONVEY OF SPEC FOR TR OFFICE TO LAB",
-            "HCPCS/G8445": "NO_DEF",
-            "HCPCS/G8447": "NO_DEF",
-            "HCPCS/J1200": "Injection, diphenhydramine hcl, up to 50 mg",
-            "ICD10CM/D64.9": "NO_DEF",
-            "ICD10CM/E03.9": "Myxedema NOS",
-            "ICD10CM/E16.3": "Hyperplasia of pancreatic endocrine cells with glucagon excess",
-            "ICD10CM/F41.9": "Anxiety NOS",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31636",
+            "date": "2008-08-13",
+            "observation": {
+                "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+                "ICD10CM/H33.319": "Horseshoe tear of retina without detachment, unspecified eye",
+                "ICD10CM/H35.039": "Hypertensive retinopathy, unspecified eye",
+                "ICD10CM/H35.049": "Retinal micro-aneurysms, unspecified, unspecified eye",
+                "ICD10CM/H57.02": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 30": {
-        "age in days": "24329",
-        "date": "2009-08-11",
-        "observation": {
-            "CPT4/84402": "Testosterone; free",
-            "CPT4/90862": "NO_DEF",
-            "ICD10CM/F31.81": "Bipolar disorder, type 2",
-            "ICD10CM/F32.4": "Major depressive disorder, single episode, in partial remission",
-            "ICD10CM/F42.2": "NO_DEF"
+        {
+            "age in days": "31645",
+            "date": "2008-08-22",
+            "observation": {
+                "CPT4/71020": "NO_DEF",
+                "ICD10CM/J98.11": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 31": {
-        "age in days": "24342",
-        "date": "2009-08-24",
-        "observation": {
-            "CPT4/72148": "MRI scan of lower spinal canal",
-            "ICD10CM/M47.819": "Spondylosis without myelopathy or radiculopathy, site unspecified",
-            "ICD10CM/M48.061": "Spinal stenosis, lumbar region NOS",
-            "ICD10CM/M51.06": "Intervertebral disc disorders with myelopathy, lumbar region",
-            "ICD10CM/M62.81": "Muscle weakness (generalized)",
-            "ICD10CM/R19.09": "Other intra-abdominal and pelvic swelling, mass and lump"
+        {
+            "age in days": "31655",
+            "date": "2008-09-01",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/L60.0": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 32": {
-        "age in days": "24349",
-        "date": "2009-08-31",
-        "observation": {
-            "ICD10CM/F06.0": "Organic hallucinatory state (nonalcoholic)",
-            "ICD10CM/K59.00": "Constipation, unspecified",
-            "ICD10CM/N81.5": "NO_DEF",
-            "ICD10CM/Z79.82": "Long term (current) use of aspirin",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31656",
+            "date": "2008-09-02",
+            "observation": {
+                "CPT4/80061": "LIPID PANEL",
+                "CPT4/82306": "Vitamin D-3 level",
+                "CPT4/85652": "SEDIMENTATION RATE RBC AUTOMATED",
+                "ICD10CM/M25.559": "Pain in unspecified hip",
+                "ICD10CM/N18.3": "Chronic kidney disease, stage 3 (moderate)",
+                "ICD10CM/R94.5": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": [
-            "Visit/IP-2.0"
-        ]
-    },
-    "day 33": {
-        "age in days": "24366",
-        "date": "2009-09-17",
-        "observation": {
-            "ICD10CM/F10.20": "Alcohol use disorder, severe",
-            "ICD10CM/F32.2": "Major depressive disorder, single episode, severe without psychotic features",
-            "ICD10CM/G40.901": "Epilepsy, unspecified, not intractable, with status epilepticus",
-            "ICD10CM/G47.33": "Obstructive sleep apnea hypopnea",
-            "ICD10CM/M12.9": "NO_DEF",
-            "ICD10CM/Z91.19": "Nonadherence to medical treatment"
+        {
+            "age in days": "31659",
+            "date": "2008-09-05",
+            "observation": {
+                "CPT4/82962": "GLUC BLD GLUC MNTR DEV CLEARED FDA SPEC HOME USE",
+                "ICD10CM/E10.65": "Type 1 diabetes mellitus with hyperglycemia",
+                "ICD10CM/E11.65": "Type 2 diabetes mellitus with hyperglycemia",
+                "ICD10CM/E11.8": "Type 2 diabetes mellitus with unspecified complications"
+            },
+            "observation with values": {}
         },
-        "observation with values": [
-            "Visit/IP-3.0"
-        ]
-    },
-    "day 34": {
-        "age in days": "24380",
-        "date": "2009-10-01",
-        "observation": {
-            "CPT4/99212": "OFFICE OUTPATIENT VISIT 10 MINUTES",
-            "ICD10CM/A01.00": "Typhoid fever, unspecified",
-            "ICD10CM/A08.8": "NO_DEF",
-            "ICD10CM/R68.0": "NO_DEF",
-            "ICD10CM/Z79.4": "Long term (current) use of insulin"
+        {
+            "age in days": "31668",
+            "date": "2008-09-14",
+            "observation": {
+                "CPT4/99202": "OFFICE OUTPATIENT NEW 20 MINUTES",
+                "ICD10CM/D48.5": "Neoplasm of uncertain behavior of anal skin",
+                "ICD10CM/L51.2": "NO_DEF",
+                "ICD10CM/L57.0": "Keratosis NOS",
+                "ICD10CM/L57.8": "NO_DEF",
+                "ICD10CM/L98.1": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 35": {
-        "age in days": "24384",
-        "date": "2009-10-05",
-        "observation": {
-            "CPT4/72131": "CT scan of lower spine",
-            "ICD10CM/M15.0": "Primary generalized (osteo)arthritis",
-            "ICD10CM/M25.519": "Pain in unspecified shoulder",
-            "ICD10CM/M51.36": "Other intervertebral disc degeneration, lumbar region",
-            "ICD10CM/M51.9": "Unspecified thoracic, thoracolumbar and lumbosacral intervertebral disc disorder",
-            "ICD10CM/M54.5": "Lumbago NOS"
+        {
+            "age in days": "31674",
+            "date": "2008-09-20",
+            "observation": {
+                "CPT4/87086": "Bacterial colony count, urine",
+                "ICD10CM/N34.3": "NO_DEF",
+                "ICD10CM/N39.0": "NO_DEF"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
         },
-        "observation with values": []
-    },
-    "day 36": {
-        "age in days": "24388",
-        "date": "2009-10-09",
-        "observation": {
-            "ATC/A02BX71": "carbenoxolone, combinations with psycholeptics",
-            "ATC/A02BX77": "gefarnate, combinations with psycholeptics",
-            "ATC/A03CA01": "isopropamide and psycholeptics",
-            "ATC/A03CA02": "clidinium and psycholeptics",
-            "ATC/A03CA03": "oxyphencyclimine and psycholeptics",
-            "ATC/A03CA04": "otilonium bromide and psycholeptics",
-            "ATC/A03CA05": "glycopyrronium bromide and psycholeptics",
-            "ATC/A03CA06": "bevonium and psycholeptics",
-            "ATC/A03CA07": "ambutonium and psycholeptics",
-            "ATC/A03CA08": "diphemanil and psycholeptics",
-            "ATC/A03CA09": "pipenzolate and psycholeptics",
-            "ATC/A03CA30": "emepronium and psycholeptics",
-            "ATC/A03CA34": "propantheline and psycholeptics",
-            "ATC/A03CB01": "methylscopolamine and psycholeptics",
-            "ATC/A03CB02": "belladonna total alkaloids and psycholeptics",
-            "ATC/A03CB03": "atropine and psycholeptics",
-            "ATC/A03CB04": "homatropine methylbromide and psycholeptics",
-            "ATC/A03CB31": "hyoscyamine and psycholeptics",
-            "ATC/C01BA71": "quinidine, combinations with psycholeptics",
-            "ATC/C01DA70": "organic nitrates in combination with psycholeptics",
-            "ATC/C02LA71": "reserpine and diuretics, combinations with psycholeptics",
-            "ATC/C02LG73": "picodralazine and diuretics, combinations with psycholeptics",
-            "ATC/C03BA82": "clorexolone, combinations with psycholeptics",
-            "ATC/M03BA71": "phenprobamate, combinations with psycholeptics",
-            "ATC/M03BA72": "carisoprodol, combinations with psycholeptics",
-            "ATC/M03BA73": "methocarbamol, combinations with psycholeptics",
-            "ATC/M03BB72": "chlormezanone, combinations with psycholeptics",
-            "ATC/M03BB73": "chlorzoxazone, combinations with psycholeptics",
-            "ATC/M09AA72": "quinine, combinations with psycholeptics",
-            "ATC/N02AB72": "pethidine, combinations with psycholeptics",
-            "ATC/N02AC74": "dextropropoxyphene, combinations with psycholeptics",
-            "ATC/N02BA71": "acetylsalicylic acid, combinations with psycholeptics",
-            "ATC/N02BA75": "salicylamide, combinations with psycholeptics",
-            "ATC/N02BA77": "ethenzamide, combinations with psycholeptics",
-            "ATC/N02BA79": "dipyrocetyl, combinations with psycholeptics",
-            "ATC/N02BB71": "phenazone, combinations with psycholeptics",
-            "ATC/N02BB72": "metamizole sodium, combinations with psycholeptics",
-            "ATC/N02BB73": "aminophenazone, combinations with psycholeptics",
-            "ATC/N02BB74": "propyphenazone, combinations with psycholeptics",
-            "ATC/N02BE71": "paracetamol, combinations with psycholeptics",
-            "ATC/N02BE73": "phenacetin, combinations with psycholeptics",
-            "ATC/N02BE74": "bucetin, combinations with psycholeptics",
-            "ATC/N02CA72": "ergotamine, combinations with psycholeptics",
-            "ATC/N05AB02": "NO_DEF",
-            "ATC/N06CA01": "amitriptyline and psycholeptics",
-            "ATC/N06CA02": "melitracen and psycholeptics",
-            "ATC/N06CA03": "fluoxetine and psycholeptics",
-            "ATC/R03DA74": "theophylline, combinations with psycholeptics"
+        {
+            "age in days": "31675",
+            "date": "2008-09-21",
+            "observation": {
+                "CPT4/1000F": "TOBACCO USE ASSESSED",
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "CPT4/97112": "THER PX 1/> AREAS EACH 15 MIN NEUROMUSC REEDUCA",
+                "CPT4/97116": "Gait training including stair climbing",
+                "CPT4/97150": "Group therapeutic procedures",
+                "CPT4/97530": "THERAPEUT ACTVITY DIRECT PT CONTACT EACH 15 MIN",
+                "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+                "HCPCS/G0008": "Administration of influenza virus vaccine",
+                "ICD10CM/G60.9": "NO_DEF",
+                "ICD10CM/M15.9": "Generalized osteoarthritis NOS",
+                "ICD10CM/M85.9": "NO_DEF",
+                "ICD10CM/Z23": "Encounter for immunization",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {
+                "Visit/OP-9.0": "NO_DEF"
+            }
         },
-        "observation with values": []
-    },
-    "day 37": {
-        "age in days": "24408",
-        "date": "2009-10-29",
-        "observation": {
-            "CPT4/99223": "INITIAL HOSPITAL CARE/DAY 70 MINUTES",
-            "ICD10CM/K56.50": "Intestinal adhesions with obstruction NOS",
-            "ICD10CM/K56.600": "Incomplete intestinal obstruction, NOS"
+        {
+            "age in days": "31676",
+            "date": "2008-09-22",
+            "observation": {
+                "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+                "ICD10CM/G56.00": "Carpal tunnel syndrome, unspecified upper limb",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 38": {
-        "age in days": "24417",
-        "date": "2009-11-07",
-        "observation": {
-            "ATC/A02BX71": "carbenoxolone, combinations with psycholeptics",
-            "ATC/A02BX77": "gefarnate, combinations with psycholeptics",
-            "ATC/A03CA01": "isopropamide and psycholeptics",
-            "ATC/A03CA02": "clidinium and psycholeptics",
-            "ATC/A03CA03": "oxyphencyclimine and psycholeptics",
-            "ATC/A03CA04": "otilonium bromide and psycholeptics",
-            "ATC/A03CA05": "glycopyrronium bromide and psycholeptics",
-            "ATC/A03CA06": "bevonium and psycholeptics",
-            "ATC/A03CA07": "ambutonium and psycholeptics",
-            "ATC/A03CA08": "diphemanil and psycholeptics",
-            "ATC/A03CA09": "pipenzolate and psycholeptics",
-            "ATC/A03CA30": "emepronium and psycholeptics",
-            "ATC/A03CA34": "propantheline and psycholeptics",
-            "ATC/A03CB01": "methylscopolamine and psycholeptics",
-            "ATC/A03CB02": "belladonna total alkaloids and psycholeptics",
-            "ATC/A03CB03": "atropine and psycholeptics",
-            "ATC/A03CB04": "homatropine methylbromide and psycholeptics",
-            "ATC/A03CB31": "hyoscyamine and psycholeptics",
-            "ATC/C01BA71": "quinidine, combinations with psycholeptics",
-            "ATC/C01DA70": "organic nitrates in combination with psycholeptics",
-            "ATC/C02LA71": "reserpine and diuretics, combinations with psycholeptics",
-            "ATC/C02LG73": "picodralazine and diuretics, combinations with psycholeptics",
-            "ATC/C03BA82": "clorexolone, combinations with psycholeptics",
-            "ATC/M03BA71": "phenprobamate, combinations with psycholeptics",
-            "ATC/M03BA72": "carisoprodol, combinations with psycholeptics",
-            "ATC/M03BA73": "methocarbamol, combinations with psycholeptics",
-            "ATC/M03BB72": "chlormezanone, combinations with psycholeptics",
-            "ATC/M03BB73": "chlorzoxazone, combinations with psycholeptics",
-            "ATC/M09AA72": "quinine, combinations with psycholeptics",
-            "ATC/N02AB72": "pethidine, combinations with psycholeptics",
-            "ATC/N02AC74": "dextropropoxyphene, combinations with psycholeptics",
-            "ATC/N02BA71": "acetylsalicylic acid, combinations with psycholeptics",
-            "ATC/N02BA75": "salicylamide, combinations with psycholeptics",
-            "ATC/N02BA77": "ethenzamide, combinations with psycholeptics",
-            "ATC/N02BA79": "dipyrocetyl, combinations with psycholeptics",
-            "ATC/N02BB71": "phenazone, combinations with psycholeptics",
-            "ATC/N02BB72": "metamizole sodium, combinations with psycholeptics",
-            "ATC/N02BB73": "aminophenazone, combinations with psycholeptics",
-            "ATC/N02BB74": "propyphenazone, combinations with psycholeptics",
-            "ATC/N02BE71": "paracetamol, combinations with psycholeptics",
-            "ATC/N02BE73": "phenacetin, combinations with psycholeptics",
-            "ATC/N02BE74": "bucetin, combinations with psycholeptics",
-            "ATC/N02CA72": "ergotamine, combinations with psycholeptics",
-            "ATC/N05AB06": "NO_DEF",
-            "ATC/N06CA01": "amitriptyline and psycholeptics",
-            "ATC/N06CA02": "melitracen and psycholeptics",
-            "ATC/N06CA03": "fluoxetine and psycholeptics",
-            "ATC/R03DA74": "theophylline, combinations with psycholeptics"
+        {
+            "age in days": "31679",
+            "date": "2008-09-25",
+            "observation": {
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "CPT4/90715": "TDAP VACCINE 7 YRS/> IM",
+                "HCPCS/G0008": "Administration of influenza virus vaccine",
+                "HCPCS/J1441": "NO_DEF",
+                "ICD10CM/D46.22": "RAEB 2",
+                "ICD10CM/D61.1": "NO_DEF",
+                "ICD10CM/R11.0": "Nausea NOS",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 39": {
-        "age in days": "24421",
-        "date": "2009-11-11",
-        "observation": {
-            "CPT4/93010": "ECG ROUTINE ECG W/LEAST 12 LDS I&R ONLY",
-            "ICD10CM/I49.3": "NO_DEF",
-            "ICD10CM/I49.8": "Ectopic rhythm disorder"
+        {
+            "age in days": "31686",
+            "date": "2008-10-02",
+            "observation": {
+                "CPT4/82043": "URINE ALBUMIN QUANTITATIVE",
+                "CPT4/83036": "HEMOGLOBIN GLYCOSYLATED A1C",
+                "CPT4/83550": "IRON BINDING CAPACITY",
+                "CPT4/84439": "Thyroxine; free",
+                "CPT4/86235": "EXTRACTABLE NUCLEAR ANTIGEN ANTIBODY ANY METHOD",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+                "ICD10CM/Z46.81": "Encounter for insulin pump titration",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 4": {
-        "age in days": "24034",
-        "date": "2008-10-20",
-        "observation": {
-            "CPT4/99231": "SBSQ HOSPITAL CARE/DAY 15 MINUTES",
-            "ICD10CM/R31.0": "NO_DEF",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31689",
+            "date": "2008-10-05",
+            "observation": {
+                "CPT4/80076": "HEPATIC FUNCTION PANEL",
+                "ICD10CM/M06.9": "NO_DEF",
+                "ICD10CM/M51.26": "Other intervertebral disc displacement, lumbar region",
+                "ICD10CM/Z08": "Encounter for follow-up examination after completed treatment for malignant neoplasm",
+                "ICD10CM/Z79.84": "Long term (current) use of oral hypoglycemic drugs",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 40": {
-        "age in days": "24442",
-        "date": "2009-12-02",
-        "observation": {
-            "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
-            "ICD10CM/C80.1": "Cancer NOS",
-            "ICD10CM/Z51.11": "Encounter for antineoplastic chemotherapy"
+        {
+            "age in days": "31696",
+            "date": "2008-10-12",
+            "observation": {
+                "CPT4/76700": "Ultrasound of abdomen",
+                "HCPCS/G0179": "Physician re-certification for medicare-covered home health services under a home health plan of care (patient not present), including contacts with home health agency and review of reports of patient status required by physicians to affirm the initial implementation of the plan of care that meets patient's needs, per re-certification period",
+                "ICD10CM/R56.9": "Fit NOS",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 41": {
-        "age in days": "24446",
-        "date": "2009-12-06",
-        "observation": {
-            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
-            "ICD10CM/R41.2": "NO_DEF",
-            "ICD10CM/Z92.25": "Personal history of immunosupression therapy",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31698",
+            "date": "2008-10-14",
+            "observation": {
+                "CPT4/99245": "OFFICE CONSULTATION NEW/ESTAB PATIENT 80 MIN",
+                "ICD10CM/M48.061": "Spinal stenosis, lumbar region NOS",
+                "ICD10CM/M50.30": "Other cervical disc degeneration, unspecified cervical region"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 42": {
-        "age in days": "24494",
-        "date": "2010-01-23",
-        "observation": {
-            "CPT4/99309": "SBSQ NURSING FACIL CARE/DAY NEW PROBLEM 25 MIN",
-            "ICD10CM/G47.419": "Narcolepsy NOS",
-            "ICD10CM/G57.90": "Unspecified mononeuropathy of unspecified lower limb",
-            "ICD10CM/I87.2": "NO_DEF",
-            "ICD10CM/M79.609": "Pain in limb NOS",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31711",
+            "date": "2008-10-27",
+            "observation": {
+                "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+                "ICD10CM/Z79.01": "Long term (current) use of anticoagulants"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 43": {
-        "age in days": "24521",
-        "date": "2010-02-19",
-        "observation": {
-            "CPT4/2027F": "OPTIC NERVE HEAD EVALUATION PERFORMED",
-            "CPT4/92014": "OPHTH MEDICAL XM&EVAL COMPRHNSV ESTAB PT 1/>",
-            "ICD10CM/E10.9": "Type 1 diabetes mellitus without complications",
-            "ICD10CM/H25.049": "Posterior subcapsular polar age-related cataract, unspecified eye",
-            "ICD10CM/H25.10": "Age-related nuclear cataract, unspecified eye",
-            "ICD10CM/H26.229": "Cataract secondary to ocular disorders (degenerative) (inflammatory), unspecified eye",
-            "ICD10CM/H43.819": "Vitreous degeneration, unspecified eye"
+        {
+            "age in days": "31712",
+            "date": "2008-10-28",
+            "observation": {
+                "CPT4/20610": "Injection of major joint",
+                "CPT4/81000": "URINLS DIP STICK/TABLET REAGNT NON-AUTO MICRSCPY",
+                "CPT4/99283": "EMERGENCY DEPARTMENT VISIT MODERATE SEVERITY",
+                "ICD10CM/M62.40": "Contracture of muscle, unspecified site",
+                "ICD10CM/M75.20": "Bicipital tendinitis, unspecified shoulder"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 44": {
-        "age in days": "24525",
-        "date": "2010-02-23",
-        "observation": {
-            "CPT4/84460": "Liver enzyme (SGPT), level",
-            "CPT4/99233": "SBSQ HOSPITAL CARE/DAY 35 MINUTES",
-            "ICD10CM/M10.00": "Idiopathic gout, unspecified site",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31715",
+            "date": "2008-10-31",
+            "observation": {
+                "CPT4/98942": "Chiropractic manipulative treatment",
+                "ICD10CM/M51.26": "Other intervertebral disc displacement, lumbar region",
+                "ICD10CM/M60.9": "NO_DEF",
+                "ICD10CM/M99.05": "Segmental and somatic dysfunction of pelvic region",
+                "ICD10CM/S33.101A": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 45": {
-        "age in days": "24526",
-        "date": "2010-02-24",
-        "observation": {
-            "CPT4/99222": "INITIAL HOSPITAL CARE/DAY 50 MINUTES",
-            "HCPCS/Q9967": "Low osmolar contrast material, 300-399 mg/ml iodine concentration, per ml",
-            "ICD10CM/K21.9": "Esophageal reflux NOS",
-            "ICD10CM/K57.30": "Diverticular disease of colon NOS",
-            "ICD10CM/K57.32": "Diverticulitis of large intestine without perforation or abscess without bleeding",
-            "ICD10CM/N28.1": "Cyst (multiple) (solitary) of kidney (acquired)"
+        {
+            "age in days": "31721",
+            "date": "2008-11-06",
+            "observation": {
+                "ICD10CM/D41.00": "Neoplasm of uncertain behavior of unspecified kidney",
+                "ICD10CM/D46.22": "RAEB 2",
+                "ICD10CM/D64.9": "NO_DEF",
+                "ICD10CM/G93.3": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 46": {
-        "age in days": "24535",
-        "date": "2010-03-05",
-        "observation": {
-            "ATC/R03AC02": "salbutamol",
-            "ATC/R03AK01": "epinephrine and other drugs for obstructive airway diseases",
-            "ATC/R03AK02": "isoprenaline and other drugs for obstructive airway diseases",
-            "ATC/R03AK04": "salbutamol and sodium cromoglicate",
-            "ATC/R03AK13": "salbutamol and beclometasone",
-            "ATC/R03AL02": "salbutamol and ipratropium bromide",
-            "ATC/R03CC02": "NO_DEF",
-            "ATC/R03DA54": "theophylline, combinations excl. psycholeptics"
+        {
+            "age in days": "31725",
+            "date": "2008-11-10",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/B07.9": "Viral wart, unspecified",
+                "ICD10CM/L57.0": "Keratosis NOS",
+                "ICD10CM/L73.2": "NO_DEF",
+                "ICD10CM/L82.1": "Seborrheic keratosis NOS",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 47": {
-        "age in days": "24551",
-        "date": "2010-03-21",
-        "observation": {
-            "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
-            "ICD10CM/F06.0": "Organic hallucinatory state (nonalcoholic)",
-            "ICD10CM/I50.814": "Right heart failure due to left heart failure",
-            "ICD10CM/N95.2": "Senile (atrophic) vaginitis",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31731",
+            "date": "2008-11-16",
+            "observation": {
+                "CPT4/17003": "Destruction of 2-14 skin growths",
+                "CPT4/4040F": "PNEUMOCOCCAL VACCINE ADMIN RCVD PRIOR",
+                "CPT4/93005": "Tracing of routine ECG with at least 12 leads",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "HCPCS/J3150": "NO_DEF",
+                "ICD10CM/S51.809A": "Unspecified open wound of unspecified forearm, initial encounter",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 48": {
-        "age in days": "24595",
-        "date": "2010-05-04",
-        "observation": {
-            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
-            "ICD10CM/J30.0": "NO_DEF",
-            "ICD10CM/K21.9": "Esophageal reflux NOS",
-            "ICD10CM/M15.9": "Generalized osteoarthritis NOS",
-            "ICD10CM/M19.249": "Secondary osteoarthritis, unspecified hand",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31745",
+            "date": "2008-11-30",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+                "ICD10CM/I50.814": "Right heart failure due to left heart failure",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 49": {
-        "age in days": "24600",
-        "date": "2010-05-09",
-        "observation": {
-            "ATC/C03AX01": "hydrochlorothiazide, combinations",
-            "ATC/C09AA03": "NO_DEF",
-            "ATC/C09BA03": "lisinopril and diuretics",
-            "ATC/C09BB03": "lisinopril and amlodipine",
-            "ATC/C10BX07": "rosuvastatin, amlodipine and lisinopril"
+        {
+            "age in days": "31756",
+            "date": "2008-12-11",
+            "observation": {
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "ICD10CM/F32.9": "Major depression NOS",
+                "ICD10CM/I10": "hypertension (arterial) (benign) (essential) (malignant) (primary) (systemic)",
+                "ICD10CM/N28.9": "Renal disease (acute) NOS",
+                "ICD10CM/R10.812": "Left upper quadrant abdominal tenderness",
+                "ICD10CM/R10.9": "Unspecified abdominal pain"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 5": {
-        "age in days": "24084",
-        "date": "2008-12-09",
-        "observation": {
-            "CPT4/99284": "EMERGENCY DEPARTMENT VISIT HIGH/URGENT SEVERITY",
-            "ICD10CM/J45.909": "Unspecified asthma, uncomplicated",
-            "ICD10CM/S01.00XA": "Unspecified open wound of scalp, initial encounter",
-            "ICD10CM/S01.512A": "Laceration without foreign body of oral cavity, initial encounter"
+        {
+            "age in days": "31782",
+            "date": "2009-01-06",
+            "observation": {
+                "CPT4/73030": "X-ray of shoulder",
+                "CPT4/97535": "Home management training",
+                "ICD10CM/M25.18": "Fistula, vertebrae"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
         },
-        "observation with values": []
-    },
-    "day 50": {
-        "age in days": "24619",
-        "date": "2010-05-28",
-        "observation": {
-            "ATC/C01DA58": "isosorbide dinitrate, combinations",
-            "ATC/C02AA52": "reserpine, combinations",
-            "ATC/C02DB02": "NO_DEF",
-            "ATC/C02LG02": "hydralazine and diuretics",
-            "ATC/C03AX01": "hydrochlorothiazide, combinations"
+        {
+            "age in days": "31791",
+            "date": "2009-01-15",
+            "observation": {
+                "CPT4/73630": "X-ray of foot",
+                "ICD10CM/B35.1": "Ringworm of nails",
+                "ICD10CM/M19.90": "Unspecified osteoarthritis, unspecified site",
+                "ICD10CM/M20.10": "Hallux valgus (acquired), unspecified foot"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 51": {
-        "age in days": "24620",
-        "date": "2010-05-29",
-        "observation": {
-            "CPT4/4048F": "DOC ANTIBIO GIVEN W/IN 1 HR PRIOR SURG/INCIS",
-            "CPT4/99223": "INITIAL HOSPITAL CARE/DAY 70 MINUTES",
-            "ICD10CM/G89.18": "Postoperative pain NOS",
-            "ICD10CM/K57.32": "Diverticulitis of large intestine without perforation or abscess without bleeding",
-            "ICD10CM/K57.33": "Diverticulitis of large intestine without perforation or abscess with bleeding",
-            "ICD10CM/L26": "Hebra's pityriasis"
+        {
+            "age in days": "31792",
+            "date": "2009-01-16",
+            "observation": {
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "CPT4/97112": "THER PX 1/> AREAS EACH 15 MIN NEUROMUSC REEDUCA",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/M46.1": "NO_DEF",
+                "ICD10CM/M48.061": "Spinal stenosis, lumbar region NOS",
+                "ICD10CM/M54.5": "Lumbago NOS",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 52": {
-        "age in days": "24634",
-        "date": "2010-06-12",
-        "observation": {
-            "ATC/A01AA51": "sodium fluoride, combinations",
-            "ATC/A02AF01": "magaldrate and antiflatulents",
-            "ATC/A02AF02": "ordinary salt combinations and antiflatulents",
-            "ATC/A06AB57": "cascara, combinations",
-            "ATC/A07BA01": "medicinal charcoal",
-            "ATC/A07BA51": "medicinal charcoal, combinations",
-            "ATC/A07FA51": "lactic acid producing organisms, combinations",
-            "ATC/A12CD51": "fluoride, combinations",
-            "ATC/C01DA52": "glyceryl trinitrate, combinations",
-            "ATC/G04BE52": "papaverine, combinations"
+        {
+            "age in days": "31798",
+            "date": "2009-01-22",
+            "observation": {
+                "CPT4/74170": "CT ABDOMEN W/O & W/CONTRAST MATERIAL",
+                "CPT4/82553": "CREATINE KINASE MB FRACTION ONLY",
+                "CPT4/82948": "GLUCOSE BLOOD REAGENT STRIP",
+                "CPT4/85018": "BLOOD COUNT HEMOGLOBIN",
+                "CPT4/99284": "EMERGENCY DEPARTMENT VISIT HIGH/URGENT SEVERITY",
+                "HCPCS/J1940": "Injection, furosemide, up to 20 mg",
+                "ICD10CM/F41.9": "Anxiety NOS",
+                "ICD10CM/I50.814": "Right heart failure due to left heart failure",
+                "ICD10CM/M25.579": "Pain in unspecified ankle and joints of unspecified foot",
+                "ICD10CM/M62.81": "Muscle weakness (generalized)",
+                "ICD10CM/R26.2": "NO_DEF",
+                "ICD10CM/S82.201A": "NO_DEF",
+                "ICD10CM/S82.401A": "NO_DEF",
+                "ICD10CM/Z90.79": "Acquired absence of other genital organ(s)"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
         },
-        "observation with values": []
-    },
-    "day 53": {
-        "age in days": "24640",
-        "date": "2010-06-18",
-        "observation": {
-            "CPT4/82310": "CALCIUM TOTAL",
-            "CPT4/86803": "HEPATITIS C ANTIBODY",
-            "ICD10CM/D63.1": "Erythropoietin resistant anemia (EPO resistant anemia)",
-            "ICD10CM/E11.29": "Type 2 diabetes mellitus with renal tubular degeneration",
-            "ICD10CM/E83.50": "Unspecified disorder of calcium metabolism",
-            "ICD10CM/I13.0": "Hypertensive heart and chronic kidney disease with heart failure and stage 1 through stage 4 chronic kidney disease, or unspecified chronic kidney disease",
-            "ICD10CM/N18.6": "Chronic kidney disease requiring chronic dialysis"
+        {
+            "age in days": "31799",
+            "date": "2009-01-23",
+            "observation": {
+                "CPT4/74020": "NO_DEF",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/R10.12": "NO_DEF",
+                "ICD10CM/R10.32": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 54": {
-        "age in days": "24648",
-        "date": "2010-06-26",
-        "observation": {
-            "ICD10CM/E46": "Protein-calorie imbalance NOS",
-            "ICD10CM/G60.9": "NO_DEF",
-            "ICD10CM/I47.2": "NO_DEF",
-            "ICD10CM/R33.9": "Retention of urine, unspecified",
-            "ICD10CM/W19.XXXA": "Unspecified fall, initial encounter",
-            "ICD10CM/Z90.710": "Acquired absence of uterus NOS",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31800",
+            "date": "2009-01-24",
+            "observation": {
+                "CPT4/97012": "Application of mechanical traction",
+                "CPT4/97124": "THER PX 1/> AREAS EACH 15 MINUTES MASSAGE",
+                "CPT4/98941": "CHIROPRACTIC MANIPULATIVE TX SPINAL 3-4 REGIONS",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "HCPCS/G0283": "Electrical stimulation (unattended), to one or more areas for indication(s) other than wound care, as part of a therapy plan of care",
+                "ICD10CM/M47.812": "Spondylosis without myelopathy or radiculopathy, cervical region",
+                "ICD10CM/M48.061": "Spinal stenosis, lumbar region NOS",
+                "ICD10CM/M50.20": "Other cervical disc displacement, unspecified cervical region",
+                "ICD10CM/M51.24": "Other intervertebral disc displacement, thoracic region",
+                "ICD10CM/M51.34": "Other intervertebral disc degeneration, thoracic region"
+            },
+            "observation with values": {}
         },
-        "observation with values": [
-            "Visit/IP-5.0"
-        ]
-    },
-    "day 55": {
-        "age in days": "24686",
-        "date": "2010-08-03",
-        "observation": {
-            "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
-            "CPT4/80051": "ELECTROLYTE PANEL",
-            "CPT4/85610": "PROTHROMBIN TIME",
-            "ICD10CM/R94.4": "Abnormal renal function test",
-            "ICD10CM/Z79.01": "Long term (current) use of anticoagulants",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31803",
+            "date": "2009-01-27",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "CPT4/99215": "OFFICE OUTPATIENT VISIT 40 MINUTES",
+                "ICD10CM/F41.9": "Anxiety NOS",
+                "ICD10CM/M05.00": "Felty's syndrome, unspecified site",
+                "ICD10CM/M06.9": "NO_DEF",
+                "ICD10CM/M81.0": "Senile osteoporosis without current pathological fracture",
+                "ICD10CM/R32": "Enuresis NOS",
+                "ICD10CM/R73.03": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 56": {
-        "age in days": "24700",
-        "date": "2010-08-17",
-        "observation": {
-            "ATC/C10AB05": "NO_DEF",
-            "ATC/C10BA03": "pravastatin and fenofibrate",
-            "ATC/C10BA04": "simvastatin and fenofibrate"
+        {
+            "age in days": "31806",
+            "date": "2009-01-30",
+            "observation": {
+                "CPT4/20600": "Injection of joint",
+                "ICD10CM/M76.60": "Achilles tendinitis, unspecified leg",
+                "ICD10CM/M77.50": "Other enthesopathy of unspecified foot and ankle"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 57": {
-        "age in days": "24713",
-        "date": "2010-08-30",
-        "observation": {
-            "CPT4/99233": "SBSQ HOSPITAL CARE/DAY 35 MINUTES",
-            "ICD10CM/N18.6": "Chronic kidney disease requiring chronic dialysis",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31809",
+            "date": "2009-02-02",
+            "observation": {
+                "CPT4/73718": "MRI scan of leg",
+                "CPT4/97150": "Group therapeutic procedures",
+                "CPT4/97530": "THERAPEUT ACTVITY DIRECT PT CONTACT EACH 15 MIN",
+                "ICD10CM/J30.0": "NO_DEF",
+                "ICD10CM/M12.239": "Villonodular synovitis (pigmented), unspecified wrist",
+                "ICD10CM/M25.569": "Pain in unspecified knee",
+                "ICD10CM/M62.81": "Muscle weakness (generalized)"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 58": {
-        "age in days": "24752",
-        "date": "2010-10-08",
-        "observation": {
-            "ATC/A04AD54": "chlorobutanol, combinations",
-            "ATC/A08AA56": "ephedrine, combinations",
-            "ATC/B03BA51": "cyanocobalamin, combinations",
-            "ATC/C01AB51": "proscillaridin, combinations",
-            "ATC/C01BA51": "quinidine, combinations excl. psycholeptics",
-            "ATC/C01DA52": "glyceryl trinitrate, combinations",
-            "ATC/C01DA55": "pentaerithrityl tetranitrate, combinations",
-            "ATC/C02AA52": "reserpine, combinations",
-            "ATC/C05BB56": "glucose, combinations",
-            "ATC/C05CA51": "rutoside, combinations",
-            "ATC/C10AD52": "nicotinic acid, combinations",
-            "ATC/G04BE52": "papaverine, combinations",
-            "ATC/J01CA51": "ampicillin, combinations",
-            "ATC/N01BA52": "procaine, combinations",
-            "ATC/N02AA59": "codeine, combinations excl. psycholeptics",
-            "ATC/N02BA57": "ethenzamide, combinations excl. psycholeptics",
-            "ATC/N02BB51": "phenazone, combinations excl. psycholeptics",
-            "ATC/N02BB52": "metamizole sodium, combinations excl. psycholeptics",
-            "ATC/N05BB51": "hydroxyzine, combinations",
-            "ATC/N05BC51": "NO_DEF",
-            "ATC/N05CX01": "meprobamate, combinations",
-            "ATC/N05CX02": "methaqualone, combinations",
-            "ATC/R01BA52": "pseudoephedrine, combinations",
-            "ATC/R01BA53": "NO_DEF",
-            "ATC/R03AK01": "epinephrine and other drugs for obstructive airway diseases",
-            "ATC/R03AK02": "isoprenaline and other drugs for obstructive airway diseases",
-            "ATC/R03CB51": "isoprenaline, combinations",
-            "ATC/R03CC53": "terbutaline, combinations",
-            "ATC/R03DA04": "NO_DEF",
-            "ATC/R03DA20": "combinations of xanthines",
-            "ATC/R03DA51": "diprophylline, combinations",
-            "ATC/R03DA54": "theophylline, combinations excl. psycholeptics",
-            "ATC/R03DA57": "theobromine, combinations",
-            "ATC/R03DA74": "theophylline, combinations with psycholeptics",
-            "ATC/R03DB04": "theophylline and adrenergics",
-            "ATC/R06AA52": "diphenhydramine, combinations",
-            "ATC/R06AA59": "doxylamine, combinations",
-            "ATC/R07AB52": "nikethamide, combinations"
+        {
+            "age in days": "31810",
+            "date": "2009-02-03",
+            "observation": {
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "CPT4/80076": "HEPATIC FUNCTION PANEL",
+                "CPT4/84100": "ASSAY OF PHOSPHORUS INORGANIC",
+                "CPT4/86900": "Blood group typing (ABO)",
+                "CPT4/93350": "ECHO TTHRC R-T 2D W/WO M-MODE COMPLETE REST&ST",
+                "CPT4/96360": "IV INFUSION HYDRATION INITIAL 31 MIN-1 HOUR",
+                "CPT4/97605": "NEGATIVE PRESSURE WOUND THERAPY DME </= 50 SQ CM",
+                "HCPCS/J7120": "Ringers lactate infusion, up to 1000 cc",
+                "ICD10CM/C90.21": "Extramedullary plasmacytoma in remission"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
         },
-        "observation with values": []
-    },
-    "day 59": {
-        "age in days": "24776",
-        "date": "2010-11-01",
-        "observation": {
-            "ATC/A06AA51": "liquid paraffin, combinations",
-            "ATC/B01AB51": "heparin, combinations",
-            "ATC/B05BC02": "NO_DEF",
-            "ATC/C05BA53": "NO_DEF",
-            "ATC/C05BB56": "glucose, combinations",
-            "ATC/C10AD52": "nicotinic acid, combinations",
-            "ATC/D01AC60": "bifonazole, combinations",
-            "ATC/D02AE01": "NO_DEF",
-            "ATC/D02AE51": "carbamide, combinations",
-            "ATC/D05AC51": "dithranol, combinations",
-            "ATC/D07XA01": "NO_DEF",
-            "ATC/D07XB02": "NO_DEF",
-            "ATC/D07XB05": "NO_DEF",
-            "ATC/D08AJ58": "benzethonium chloride, combinations",
-            "ATC/D10AD51": "tretinoin, combinations",
-            "ATC/G03CA53": "estradiol, combinations",
-            "ATC/N01BB52": "lidocaine, combinations",
-            "ATC/R03DA54": "theophylline, combinations excl. psycholeptics",
-            "ATC/R03DA57": "theobromine, combinations"
+        {
+            "age in days": "31811",
+            "date": "2009-02-04",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/K21.9": "Esophageal reflux NOS",
+                "ICD10CM/K22.8": "Hemorrhage of esophagus NOS"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 6": {
-        "age in days": "24111",
-        "date": "2009-01-05",
-        "observation": {
-            "CPT4/85025": "Automated platelet count",
-            "CPT4/88305": "LEVEL IV SURG PATHOLOGY GROSS&MICROSCOPIC EXAM",
-            "ICD10CM/C34.80": "Malignant neoplasm of overlapping sites of unspecified bronchus and lung",
-            "None/No matching concept": "NO_DEF"
+        {
+            "age in days": "31818",
+            "date": "2009-02-11",
+            "observation": {
+                "CPT4/82565": "CREATININE BLOOD",
+                "CPT4/84403": "Testosterone; total",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "HCPCS/J3420": "Injection, vitamin b-12 cyanocobalamin, up to 1000 mcg",
+                "ICD10CM/M17.10": "Unilateral primary osteoarthritis, unspecified knee",
+                "ICD10CM/M67.50": "Plica syndrome, unspecified knee",
+                "ICD10CM/S43.109A": "NO_DEF",
+                "ICD10CM/S83.219A": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 7": {
-        "age in days": "24113",
-        "date": "2009-01-07",
-        "observation": {
-            "ATC/N02BA51": "acetylsalicylic acid, combinations excl. psycholeptics",
-            "ATC/N02BE51": "paracetamol, combinations excl. psycholeptics",
-            "ATC/N04BA01": "NO_DEF",
-            "ATC/N04BA02": "levodopa and decarboxylase inhibitor",
-            "ATC/N04BA03": "levodopa, decarboxylase inhibitor and COMT inhibitor",
-            "ATC/N04BA05": "melevodopa and decarboxylase inhibitor",
-            "ATC/N04BA06": "etilevodopa and decarboxylase inhibitor"
+        {
+            "age in days": "31827",
+            "date": "2009-02-20",
+            "observation": {
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "CPT4/81001": "URNLS DIP STICK/TABLET REAGENT AUTO MICROSCOPY",
+                "CPT4/84100": "ASSAY OF PHOSPHORUS INORGANIC",
+                "CPT4/84165": "Protein measurement, serum",
+                "ICD10CM/R71.8": "Abnormal red-cell volume NOS",
+                "ICD10CM/Z00.6": "Examination of participant or control in clinical research program",
+                "ICD10CM/Z79.84": "Long term (current) use of oral hypoglycemic drugs"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 8": {
-        "age in days": "24118",
-        "date": "2009-01-12",
-        "observation": {
-            "ATC/N02BA51": "acetylsalicylic acid, combinations excl. psycholeptics",
-            "ATC/N02BE51": "paracetamol, combinations excl. psycholeptics",
-            "ATC/N04BA01": "NO_DEF",
-            "ATC/N04BA02": "levodopa and decarboxylase inhibitor",
-            "ATC/N04BA03": "levodopa, decarboxylase inhibitor and COMT inhibitor",
-            "ATC/N04BA05": "melevodopa and decarboxylase inhibitor",
-            "ATC/N04BA06": "etilevodopa and decarboxylase inhibitor"
+        {
+            "age in days": "31834",
+            "date": "2009-02-27",
+            "observation": {
+                "CPT4/51741": "COMPLEX UROFLOMETRY",
+                "ICD10CM/N40.1": "Enlarged prostate with LUTS"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    },
-    "day 9": {
-        "age in days": "24119",
-        "date": "2009-01-13",
-        "observation": {
-            "CPT4/00120": "Anesthesia for procedure on inner ear",
-            "ICD10CM/Z48.03": "Encounter for change or removal of drains",
-            "ICD10CM/Z79.4": "Long term (current) use of insulin"
+        {
+            "age in days": "31836",
+            "date": "2009-03-01",
+            "observation": {
+                "HCPCS/J1100": "Injection, dexamethasone sodium phosphate, 1 mg",
+                "ICD10CM/M11.89": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
         },
-        "observation with values": []
-    }
+        {
+            "age in days": "31838",
+            "date": "2009-03-03",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/E03.9": "Myxedema NOS",
+                "ICD10CM/I50.814": "Right heart failure due to left heart failure",
+                "ICD10CM/Z46.81": "Encounter for insulin pump titration"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
+        },
+        {
+            "age in days": "31841",
+            "date": "2009-03-06",
+            "observation": {
+                "CPT4/99203": "OFFICE OUTPATIENT NEW 30 MINUTES",
+                "HCPCS/J1030": "Injection, methylprednisolone acetate, 40 mg",
+                "HCPCS/J2001": "Injection, lidocaine hcl for intravenous infusion, 10 mg",
+                "ICD10CM/M17.9": "Osteoarthritis of knee, unspecified",
+                "ICD10CM/M25.519": "Pain in unspecified shoulder",
+                "ICD10CM/M65.20": "Calcific tendinitis, unspecified site",
+                "ICD10CM/M75.00": "Adhesive capsulitis of unspecified shoulder",
+                "ICD10CM/M75.30": "Calcific tendinitis of unspecified shoulder",
+                "ICD10CM/N18.3": "Chronic kidney disease, stage 3 (moderate)",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31845",
+            "date": "2009-03-10",
+            "observation": {
+                "CPT4/95117": "PROF SVCS ALLG IMMNTX X W/PRV ALLGIC XTRCS NJXS",
+                "ICD10CM/J30.1": "Allergy NOS due to pollen",
+                "ICD10CM/J30.2": "NO_DEF",
+                "ICD10CM/J34.3": "NO_DEF",
+                "ICD10CM/J39.2": "NO_DEF",
+                "ICD10CM/K21.9": "Esophageal reflux NOS"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31853",
+            "date": "2009-03-18",
+            "observation": {
+                "CPT4/72148": "MRI scan of lower spinal canal",
+                "ICD10CM/M12.9": "NO_DEF",
+                "ICD10CM/M25.559": "Pain in unspecified hip",
+                "ICD10CM/M46.40": "Discitis, unspecified, site unspecified",
+                "ICD10CM/M54.89": "NO_DEF"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
+        },
+        {
+            "age in days": "31855",
+            "date": "2009-03-20",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/E11.311": "Type 2 diabetes mellitus with unspecified diabetic retinopathy with macular edema",
+                "ICD10CM/E11.40": "Type 2 diabetes mellitus with diabetic neuropathy, unspecified",
+                "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+                "ICD10CM/L60.0": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31865",
+            "date": "2009-03-30",
+            "observation": {
+                "CPT4/87086": "Bacterial colony count, urine",
+                "CPT4/98940": "CHIROPRACTIC MANIPULATIVE TX SPINAL 1-2 REGIONS",
+                "ICD10CM/E78.00": "(Pure) hypercholesterolemia NOS",
+                "ICD10CM/G30.9": "NO_DEF",
+                "ICD10CM/M25.60": "Stiffness of unspecified joint, not elsewhere classified",
+                "ICD10CM/M51.36": "Other intervertebral disc degeneration, lumbar region",
+                "ICD10CM/M62.40": "Contracture of muscle, unspecified site",
+                "ICD10CM/M93.20": "Osteochondritis dissecans of unspecified site",
+                "ICD10CM/N30.40": "NO_DEF",
+                "ICD10CM/N39.0": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31876",
+            "date": "2009-04-10",
+            "observation": {
+                "CPT4/97140": "Manual therapy techniques",
+                "ICD10CM/M75.120": "Complete rotator cuff tear or rupture of unspecified shoulder, not specified as traumatic",
+                "ICD10CM/M76.899": "Other specified enthesopathies of unspecified lower limb, excluding foot"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31885",
+            "date": "2009-04-19",
+            "observation": {
+                "HCPCS/G0283": "Electrical stimulation (unattended), to one or more areas for indication(s) other than wound care, as part of a therapy plan of care",
+                "ICD10CM/M51.34": "Other intervertebral disc degeneration, thoracic region",
+                "ICD10CM/M51.36": "Other intervertebral disc degeneration, lumbar region"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31886",
+            "date": "2009-04-20",
+            "observation": {
+                "CPT4/76705": "Real time ultrasound of abdomen",
+                "ICD10CM/R10.84": "NO_DEF",
+                "ICD10CM/R10.9": "Unspecified abdominal pain"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31891",
+            "date": "2009-04-25",
+            "observation": {
+                "CPT4/73562": "X-ray of knee, 3 views",
+                "CPT4/74150": "CT scan abdomen",
+                "CPT4/81001": "URNLS DIP STICK/TABLET REAGENT AUTO MICROSCOPY",
+                "CPT4/82272": "BLOOD OCCULT PEROXIDASE ACTV QUAL FECES 1-3 SPEC",
+                "CPT4/82274": "Stool analysis for blood",
+                "CPT4/82715": "FAT DIFFIAL FECES QUANTITATIVE",
+                "CPT4/87015": "CONCENTRATION INFECTIOUS AGENTS",
+                "CPT4/87045": "Aerobic bacterial culture of stool",
+                "CPT4/87046": "CUL BACT STOOL AEROBIC ADDL PATHOGENS&ID EA",
+                "CPT4/87177": "Smear for parasites",
+                "CPT4/87209": "Special stain for parasites",
+                "CPT4/87324": "IAAD IA CLOSTRIDIUM DIFFICILE TOXIN",
+                "CPT4/87328": "IAAD IA CRYPTOSPORIDIUM",
+                "CPT4/87329": "IAAD IA GIARDIA",
+                "CPT4/87899": "IAADIADOO NOT OTHERWISE SPECIFIED",
+                "CPT4/89055": "White blood cell measure, stool specimen",
+                "CPT4/94360": "NO_DEF",
+                "CPT4/96372": "Subcutaneous diagnostic injection",
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "CPT4/97530": "THERAPEUT ACTVITY DIRECT PT CONTACT EACH 15 MIN",
+                "HCPCS/J1200": "Injection, diphenhydramine hcl, up to 50 mg",
+                "HCPCS/J1650": "Injection, enoxaparin sodium, 10 mg",
+                "HCPCS/J2175": "Injection, meperidine hydrochloride, per 100 mg",
+                "ICD10CM/M17.9": "Osteoarthritis of knee, unspecified",
+                "ICD10CM/M24.669": "Ankylosis, unspecified knee",
+                "ICD10CM/M70.60": "Trochanteric bursitis, unspecified hip",
+                "ICD10CM/M71.20": "Synovial cyst of popliteal space [Baker], unspecified knee",
+                "ICD10CM/M79.609": "Pain in limb NOS",
+                "ICD10CM/S83.90XA": "Sprain of unspecified site of unspecified knee, initial encounter",
+                "ICD10CM/S89.80XA": "Other specified injuries of unspecified lower leg, initial encounter",
+                "ICD10CM/Z86.73": "Personal history of stroke NOS without residual deficits",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {
+                "Visit/OP-20.0": "NO_DEF"
+            }
+        },
+        {
+            "age in days": "31896",
+            "date": "2009-04-30",
+            "observation": {
+                "CPT4/90658": "IIV3 VACCINE SPLIT VIRUS 0.5 ML DOSAGE IM USE",
+                "CPT4/99212": "OFFICE OUTPATIENT VISIT 10 MINUTES",
+                "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+                "ICD10CM/Z20.6": "Contact with and (suspected) exposure to human immunodeficiency virus [HIV]",
+                "ICD10CM/Z23": "Encounter for immunization"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31900",
+            "date": "2009-05-04",
+            "observation": {
+                "CPT4/97010": "Application of hot or cold packs",
+                "CPT4/97026": "Application of infrared modality",
+                "CPT4/97032": "APPL MODALITY 1/> AREAS ELEC STIMJ EA 15 MIN",
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "CPT4/97112": "THER PX 1/> AREAS EACH 15 MIN NEUROMUSC REEDUCA",
+                "CPT4/97116": "Gait training including stair climbing",
+                "CPT4/97542": "Wheelchair management",
+                "ICD10CM/M67.88": "Other specified disorders of synovium and tendon, other site"
+            },
+            "observation with values": {
+                "Visit/OP-12.0": "NO_DEF"
+            }
+        },
+        {
+            "age in days": "31930",
+            "date": "2009-06-03",
+            "observation": {
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "CPT4/97112": "THER PX 1/> AREAS EACH 15 MIN NEUROMUSC REEDUCA",
+                "CPT4/99283": "EMERGENCY DEPARTMENT VISIT MODERATE SEVERITY",
+                "ICD10CM/S93.409A": "Sprain of unspecified ligament of unspecified ankle, initial encounter",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31931",
+            "date": "2009-06-04",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/M17.10": "Unilateral primary osteoarthritis, unspecified knee",
+                "ICD10CM/M17.5": "Secondary osteoarthritis of knee NOS",
+                "ICD10CM/M19.239": "Secondary osteoarthritis, unspecified wrist",
+                "ICD10CM/M25.569": "Pain in unspecified knee"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31946",
+            "date": "2009-06-19",
+            "observation": {
+                "CPT4/98941": "CHIROPRACTIC MANIPULATIVE TX SPINAL 3-4 REGIONS",
+                "ICD10CM/M51.24": "Other intervertebral disc displacement, thoracic region",
+                "ICD10CM/S02.91XK": "Unspecified fracture of skull, subsequent encounter for fracture with nonunion",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31948",
+            "date": "2009-06-21",
+            "observation": {
+                "CPT4/99215": "OFFICE OUTPATIENT VISIT 40 MINUTES",
+                "ICD10CM/T30.0": "Burn NOS",
+                "ICD10CM/T31.22": "Burns involving 20-29% of body surface with 20-29% third degree burns"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31954",
+            "date": "2009-06-27",
+            "observation": {
+                "ICD10CM/E28.9": "NO_DEF",
+                "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+                "ICD10CM/M79.609": "Pain in limb NOS",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31964",
+            "date": "2009-07-07",
+            "observation": {
+                "CPT4/73221": "MRI of wrist joint",
+                "ICD10CM/M25.519": "Pain in unspecified shoulder",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31967",
+            "date": "2009-07-10",
+            "observation": {
+                "CPT4/76700": "Ultrasound of abdomen",
+                "ICD10CM/E86.0": "NO_DEF",
+                "ICD10CM/K57.30": "Diverticular disease of colon NOS",
+                "ICD10CM/K59.03": "Drug induced constipation",
+                "ICD10CM/R10.811": "Right upper quadrant abdominal tenderness",
+                "ICD10CM/R10.84": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31969",
+            "date": "2009-07-12",
+            "observation": {
+                "CPT4/81003": "Automated urinalysis test",
+                "CPT4/83036": "HEMOGLOBIN GLYCOSYLATED A1C",
+                "CPT4/85610": "PROTHROMBIN TIME",
+                "CPT4/99000": "HANDLG&/OR CONVEY OF SPEC FOR TR OFFICE TO LAB",
+                "HCPCS/G8445": "NO_DEF",
+                "HCPCS/P9603": "Travel allowance one way in connection with medically necessary laboratory specimen collection drawn from home bound or nursing home bound patient; prorated miles actually travelled",
+                "ICD10CM/E03.9": "Myxedema NOS",
+                "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+                "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+                "ICD10CM/Z99.0": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "31996",
+            "date": "2009-08-08",
+            "observation": {
+                "CPT4/99203": "OFFICE OUTPATIENT NEW 30 MINUTES",
+                "ICD10CM/M20.10": "Hallux valgus (acquired), unspecified foot",
+                "ICD10CM/M20.40": "Other hammer toe(s) (acquired), unspecified foot"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32000",
+            "date": "2009-08-12",
+            "observation": {
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "ICD10CM/D50.9": "NO_DEF",
+                "ICD10CM/D61.01": "Blackfan-Diamond syndrome"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32005",
+            "date": "2009-08-17",
+            "observation": {
+                "ATC/A02BX71": "carbenoxolone, combinations with psycholeptics",
+                "ATC/A02BX77": "gefarnate, combinations with psycholeptics",
+                "ATC/A03CA01": "isopropamide and psycholeptics",
+                "ATC/A03CA02": "clidinium and psycholeptics",
+                "ATC/A03CA03": "oxyphencyclimine and psycholeptics",
+                "ATC/A03CA04": "otilonium bromide and psycholeptics",
+                "ATC/A03CA05": "glycopyrronium bromide and psycholeptics",
+                "ATC/A03CA06": "bevonium and psycholeptics",
+                "ATC/A03CA07": "ambutonium and psycholeptics",
+                "ATC/A03CA08": "diphemanil and psycholeptics",
+                "ATC/A03CA09": "pipenzolate and psycholeptics",
+                "ATC/A03CA30": "emepronium and psycholeptics",
+                "ATC/A03CA34": "propantheline and psycholeptics",
+                "ATC/A03CB01": "methylscopolamine and psycholeptics",
+                "ATC/A03CB02": "belladonna total alkaloids and psycholeptics",
+                "ATC/A03CB03": "atropine and psycholeptics",
+                "ATC/A03CB04": "homatropine methylbromide and psycholeptics",
+                "ATC/A03CB31": "hyoscyamine and psycholeptics",
+                "ATC/C01BA71": "quinidine, combinations with psycholeptics",
+                "ATC/C01DA70": "organic nitrates in combination with psycholeptics",
+                "ATC/C02LA71": "reserpine and diuretics, combinations with psycholeptics",
+                "ATC/C02LG73": "picodralazine and diuretics, combinations with psycholeptics",
+                "ATC/C03BA82": "clorexolone, combinations with psycholeptics",
+                "ATC/M03BA71": "phenprobamate, combinations with psycholeptics",
+                "ATC/M03BA72": "carisoprodol, combinations with psycholeptics",
+                "ATC/M03BA73": "methocarbamol, combinations with psycholeptics",
+                "ATC/M03BB72": "chlormezanone, combinations with psycholeptics",
+                "ATC/M03BB73": "chlorzoxazone, combinations with psycholeptics",
+                "ATC/M09AA72": "quinine, combinations with psycholeptics",
+                "ATC/N02AB72": "pethidine, combinations with psycholeptics",
+                "ATC/N02AC74": "dextropropoxyphene, combinations with psycholeptics",
+                "ATC/N02BA71": "acetylsalicylic acid, combinations with psycholeptics",
+                "ATC/N02BA75": "salicylamide, combinations with psycholeptics",
+                "ATC/N02BA77": "ethenzamide, combinations with psycholeptics",
+                "ATC/N02BA79": "dipyrocetyl, combinations with psycholeptics",
+                "ATC/N02BB71": "phenazone, combinations with psycholeptics",
+                "ATC/N02BB72": "metamizole sodium, combinations with psycholeptics",
+                "ATC/N02BB73": "aminophenazone, combinations with psycholeptics",
+                "ATC/N02BB74": "propyphenazone, combinations with psycholeptics",
+                "ATC/N02BE71": "paracetamol, combinations with psycholeptics",
+                "ATC/N02BE73": "phenacetin, combinations with psycholeptics",
+                "ATC/N02BE74": "bucetin, combinations with psycholeptics",
+                "ATC/N02CA72": "ergotamine, combinations with psycholeptics",
+                "ATC/N05BA06": "NO_DEF",
+                "ATC/N05BA56": "lorazepam, combinations",
+                "ATC/N06CA01": "amitriptyline and psycholeptics",
+                "ATC/N06CA02": "melitracen and psycholeptics",
+                "ATC/N06CA03": "fluoxetine and psycholeptics",
+                "ATC/R03DA74": "theophylline, combinations with psycholeptics",
+                "CPT4/72193": "CT scan pelvis with contrast",
+                "CPT4/82565": "CREATININE BLOOD",
+                "CPT4/83036": "HEMOGLOBIN GLYCOSYLATED A1C",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/C54.8": "Malignant neoplasm of overlapping sites of corpus uteri"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
+        },
+        {
+            "age in days": "32013",
+            "date": "2009-08-25",
+            "observation": {
+                "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+                "CPT4/99232": "SBSQ HOSPITAL CARE/DAY 25 MINUTES",
+                "CPT4/99238": "HOSPITAL DISCHARGE DAY MANAGEMENT 30 MIN/<",
+                "ICD10CM/M48.00": "NO_DEF",
+                "ICD10CM/M48.061": "Spinal stenosis, lumbar region NOS",
+                "ICD10CM/M53.3": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32015",
+            "date": "2009-08-27",
+            "observation": {
+                "CPT4/71010": "NO_DEF",
+                "CPT4/72192": "CT scan pelvis",
+                "CPT4/74150": "CT scan abdomen",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/C83.16": "Mantle cell lymphoma, intrapelvic lymph nodes",
+                "ICD10CM/C85.80": "Other specified types of non-Hodgkin lymphoma, unspecified site",
+                "ICD10CM/M50.30": "Other cervical disc degeneration, unspecified cervical region",
+                "ICD10CM/M51.36": "Other intervertebral disc degeneration, lumbar region",
+                "ICD10CM/M54.14": "NO_DEF",
+                "ICD10CM/Z79.84": "Long term (current) use of oral hypoglycemic drugs"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32025",
+            "date": "2009-09-06",
+            "observation": {
+                "CPT4/10060": "Incision and drainage of carbuncle",
+                "CPT4/82550": "CREATINE KINASE TOTAL",
+                "CPT4/94640": "PRESSURIZED/NONPRESSURIZED INHALATION TREATMENT",
+                "HCPCS/C1894": "Introducer/sheath, other than guiding, other than intracardiac electrophysiological, non-laser",
+                "HCPCS/G0206": "NO_DEF",
+                "ICD10CM/D78.01": "Intraoperative hemorrhage and hematoma of the spleen complicating a procedure on the spleen",
+                "ICD10CM/T81.30XA": "Disruption of wound, unspecified, initial encounter",
+                "ICD10CM/T81.83XA": "Persistent postprocedural fistula, initial encounter",
+                "ICD10CM/Z86.73": "Personal history of stroke NOS without residual deficits",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
+        },
+        {
+            "age in days": "32032",
+            "date": "2009-09-13",
+            "observation": {
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "CPT4/76700": "Ultrasound of abdomen",
+                "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+                "ICD10CM/E78.00": "(Pure) hypercholesterolemia NOS",
+                "ICD10CM/K59.00": "Constipation, unspecified",
+                "ICD10CM/K74.0": "NO_DEF",
+                "ICD10CM/K75.1": "NO_DEF",
+                "ICD10CM/R94.5": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32040",
+            "date": "2009-09-21",
+            "observation": {
+                "CPT4/64475": "NO_DEF",
+                "ICD10CM/M46.1": "NO_DEF",
+                "ICD10CM/M47.817": "Spondylosis without myelopathy or radiculopathy, lumbosacral region"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32042",
+            "date": "2009-09-23",
+            "observation": {
+                "CPT4/99232": "SBSQ HOSPITAL CARE/DAY 25 MINUTES",
+                "HCPCS/G8553": "NO_DEF",
+                "ICD10CM/K21.9": "Esophageal reflux NOS",
+                "ICD10CM/K57.30": "Diverticular disease of colon NOS",
+                "ICD10CM/K57.32": "Diverticulitis of large intestine without perforation or abscess without bleeding"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32046",
+            "date": "2009-09-27",
+            "observation": {
+                "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+                "ICD10CM/G47.52": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32050",
+            "date": "2009-10-01",
+            "observation": {
+                "CPT4/72110": "RADEX SPINE LUMBOSACRAL MINIMUM 4 VIEWS",
+                "ICD10CM/D64.9": "NO_DEF",
+                "ICD10CM/M48.061": "Spinal stenosis, lumbar region NOS",
+                "ICD10CM/M48.9": "NO_DEF",
+                "ICD10CM/M51.36": "Other intervertebral disc degeneration, lumbar region",
+                "ICD10CM/M54.10": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32058",
+            "date": "2009-10-09",
+            "observation": {
+                "CPT4/99233": "SBSQ HOSPITAL CARE/DAY 35 MINUTES",
+                "ICD10CM/I21.11": "Inferoposterior transmural (Q wave) infarction (acute)",
+                "ICD10CM/I21.4": "Non-Q wave myocardial infarction NOS",
+                "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+                "ICD10CM/I50.21": "Acute systolic (congestive) heart failure",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32062",
+            "date": "2009-10-13",
+            "observation": {
+                "CPT4/70544": "MRA of head without contrast",
+                "ICD10CM/D72.829": "Elevated leukocytes, unspecified",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
+        },
+        {
+            "age in days": "32068",
+            "date": "2009-10-19",
+            "observation": {
+                "ATC/A10BH51": "sitagliptin and simvastatin",
+                "ATC/C10AA01": "NO_DEF",
+                "ATC/C10AD52": "nicotinic acid, combinations",
+                "ATC/C10BA02": "simvastatin and ezetimibe",
+                "ATC/C10BA04": "simvastatin and fenofibrate",
+                "ATC/C10BX01": "simvastatin and acetylsalicylic acid",
+                "ATC/C10BX04": "simvastatin, acetylsalicylic acid and ramipril",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/J44.0": "Chronic obstructive pulmonary disease with (acute) lower respiratory infection",
+                "ICD10CM/M25.569": "Pain in unspecified knee",
+                "ICD10CM/M34.81": "Systemic sclerosis with lung involvement",
+                "ICD10CM/M47.812": "Spondylosis without myelopathy or radiculopathy, cervical region",
+                "ICD10CM/R06.9": "Unspecified abnormalities of breathing"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32076",
+            "date": "2009-10-27",
+            "observation": {
+                "CPT4/17000": "Destruction of skin growth",
+                "CPT4/99051": "SVC PRV OFFICE REG SCHEDD EVN WKEND/HOLIDAY HRS",
+                "CPT4/99212": "OFFICE OUTPATIENT VISIT 10 MINUTES",
+                "HCPCS/G8443": "NO_DEF",
+                "ICD10CM/M19.90": "Unspecified osteoarthritis, unspecified site",
+                "ICD10CM/M51.36": "Other intervertebral disc degeneration, lumbar region",
+                "ICD10CM/M54.08": "NO_DEF",
+                "ICD10CM/M66.259": "Spontaneous rupture of extensor tendons, unspecified thigh",
+                "ICD10CM/M75.80": "Other shoulder lesions, unspecified shoulder"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32077",
+            "date": "2009-10-28",
+            "observation": {
+                "ATC/C03AX01": "hydrochlorothiazide, combinations",
+                "ATC/C07AG01": "NO_DEF",
+                "ATC/C07BG01": "labetalol and thiazides",
+                "ATC/C07CG01": "labetalol and other diuretics",
+                "ATC/N05BB51": "hydroxyzine, combinations",
+                "CPT4/82306": "Vitamin D-3 level",
+                "CPT4/84443": "Thyroid stimulating hormone (TSH)",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/E10.51": "Type 1 diabetes mellitus with diabetic peripheral angiopathy without gangrene",
+                "ICD10CM/E11.65": "Type 2 diabetes mellitus with hyperglycemia"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32085",
+            "date": "2009-11-05",
+            "observation": {
+                "CPT4/93224": "XTRNL ECG & 48 HR RECORD SCAN STOR W/R&I",
+                "CPT4/93306": "ECHO TTHRC R-T 2D W/WOM-MODE COMPL SPEC&COLR D",
+                "CPT4/99232": "SBSQ HOSPITAL CARE/DAY 25 MINUTES",
+                "ICD10CM/E03.9": "Myxedema NOS",
+                "ICD10CM/E78.00": "(Pure) hypercholesterolemia NOS",
+                "ICD10CM/G93.3": "NO_DEF",
+                "ICD10CM/I21.09": "Anteroapical transmural (Q wave) infarction (acute)",
+                "ICD10CM/S09.8XXA": "Other specified injuries of head, initial encounter",
+                "ICD10CM/W19.XXXA": "Unspecified fall, initial encounter",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32088",
+            "date": "2009-11-08",
+            "observation": {
+                "ATC/A03DA01": "tropenzilone and analgesics",
+                "ATC/A03DA02": "pitofenone and analgesics",
+                "ATC/A03DA03": "bevonium and analgesics",
+                "ATC/A03DA04": "ciclonium and analgesics",
+                "ATC/A03DA05": "camylofin and analgesics",
+                "ATC/A03DA06": "trospium and analgesics",
+                "ATC/A03DA07": "tiemonium iodide and analgesics",
+                "ATC/A03DB04": "butylscopolamine and analgesics",
+                "ATC/A04AD51": "scopolamine, combinations",
+                "ATC/A06AD61": "lactulose, combinations",
+                "ATC/A07DA53": "loperamide, combinations",
+                "ATC/A08AA56": "ephedrine, combinations",
+                "ATC/B03BA51": "cyanocobalamin, combinations",
+                "ATC/G04BE52": "papaverine, combinations",
+                "ATC/M01AB55": "diclofenac, combinations",
+                "ATC/M01AE51": "ibuprofen, combinations",
+                "ATC/M01AE53": "ketoprofen, combinations",
+                "ATC/M03BA51": "phenprobamate, combinations excl. psycholeptics",
+                "ATC/M03BA52": "carisoprodol, combinations excl. psycholeptics",
+                "ATC/M03BA53": "methocarbamol, combinations excl. psycholeptics",
+                "ATC/M03BB52": "chlormezanone, combinations excl. psycholeptics",
+                "ATC/M03BB53": "chlorzoxazone, combinations excl. psycholeptics",
+                "ATC/M03BC51": "orphenadrine, combinations",
+                "ATC/M03BX55": "thiocolchicoside, combinations",
+                "ATC/N01BA52": "procaine, combinations",
+                "ATC/N01BB52": "lidocaine, combinations",
+                "ATC/N02AA58": "dihydrocodeine, combinations",
+                "ATC/N02AA59": "codeine, combinations excl. psycholeptics",
+                "ATC/N02AB52": "pethidine, combinations excl. psycholeptics",
+                "ATC/N02AC04": "NO_DEF",
+                "ATC/N02AC52": "methadone, combinations excl. psycholeptics",
+                "ATC/N02AC54": "dextropropoxyphene, combinations excl. psycholeptics",
+                "ATC/N02AC74": "dextropropoxyphene, combinations with psycholeptics",
+                "ATC/N02AJ01": "dihydrocodeine and paracetamol",
+                "ATC/N02AJ06": "codeine and paracetamol",
+                "ATC/N02AJ13": "tramadol and paracetamol",
+                "ATC/N02AJ17": "oxycodone and paracetamol",
+                "ATC/N02BA51": "acetylsalicylic acid, combinations excl. psycholeptics",
+                "ATC/N02BA55": "salicylamide, combinations excl. psycholeptics",
+                "ATC/N02BA57": "ethenzamide, combinations excl. psycholeptics",
+                "ATC/N02BB51": "phenazone, combinations excl. psycholeptics",
+                "ATC/N02BB52": "metamizole sodium, combinations excl. psycholeptics",
+                "ATC/N02BB53": "aminophenazone, combinations excl. psycholeptics",
+                "ATC/N02BE01": "paracetamol",
+                "ATC/N02BE51": "paracetamol, combinations excl. psycholeptics",
+                "ATC/N02BE53": "phenacetin, combinations excl. psycholeptics",
+                "ATC/N02BE54": "bucetin, combinations excl. psycholeptics",
+                "ATC/N02BE71": "paracetamol, combinations with psycholeptics",
+                "ATC/N02CA51": "dihydroergotamine, combinations",
+                "ATC/N02CA52": "ergotamine, combinations excl. psycholeptics",
+                "ATC/N05BC51": "NO_DEF",
+                "ATC/N05CX01": "meprobamate, combinations",
+                "ATC/N05CX02": "methaqualone, combinations",
+                "ATC/N07XX59": "dextromethorphan, combinations",
+                "ATC/P01AX52": "emetine, combinations",
+                "ATC/R01BA51": "phenylpropanolamine, combinations",
+                "ATC/R01BA52": "pseudoephedrine, combinations",
+                "ATC/R01BA53": "NO_DEF",
+                "ATC/R03DA51": "diprophylline, combinations",
+                "ATC/R03DA57": "theobromine, combinations",
+                "ATC/R06AA52": "diphenhydramine, combinations",
+                "ATC/R06AA54": "clemastine, combinations",
+                "ATC/R06AA57": "diphenylpyraline, combinations",
+                "ATC/R06AA59": "doxylamine, combinations",
+                "ATC/R06AB51": "brompheniramine, combinations",
+                "ATC/R06AB52": "dexchlorpheniramine, combinations",
+                "ATC/R06AB54": "chlorphenamine, combinations",
+                "ATC/R06AB56": "dexbrompheniramine, combinations",
+                "ATC/R06AD52": "promethazine, combinations",
+                "ATC/R06AE51": "buclizine, combinations"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32096",
+            "date": "2009-11-16",
+            "observation": {
+                "CPT4/93880": "DUPLEX SCAN EXTRACRANIAL ART COMPL BI STUDY",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32098",
+            "date": "2009-11-18",
+            "observation": {
+                "ATC/C02AA52": "reserpine, combinations",
+                "ATC/C02LA01": "reserpine and diuretics",
+                "ATC/C02LA02": "rescinnamine and diuretics",
+                "ATC/C02LA03": "deserpidine and diuretics",
+                "ATC/C02LA04": "methoserpidine and diuretics",
+                "ATC/C02LA07": "bietaserpine and diuretics",
+                "ATC/C02LA08": "rauwolfia alkaloids, whole root and diuretics",
+                "ATC/C02LA09": "syrosingopine and diuretics",
+                "ATC/C02LA50": "combination of rauwolfia alkaloids and diuretics incl. other combinations",
+                "ATC/C02LA71": "reserpine and diuretics, combinations with psycholeptics",
+                "ATC/C02LB01": "methyldopa (levorotatory) and diuretics",
+                "ATC/C02LC01": "clonidine and diuretics",
+                "ATC/C02LC05": "moxonidine and diuretics",
+                "ATC/C02LC51": "clonidine and diuretics, combinations with other drugs",
+                "ATC/C02LE01": "prazosin and diuretics",
+                "ATC/C02LF01": "guanethidine and diuretics",
+                "ATC/C02LG01": "dihydralazine and diuretics",
+                "ATC/C02LG02": "hydralazine and diuretics",
+                "ATC/C02LG03": "picodralazine and diuretics",
+                "ATC/C02LG73": "picodralazine and diuretics, combinations with psycholeptics",
+                "ATC/C02LK01": "veratrum and diuretics",
+                "ATC/C02LL01": "pargyline and diuretics",
+                "ATC/C02LX01": "pinacidil and diuretics",
+                "ATC/C03AA03": "NO_DEF",
+                "ATC/C03AB03": "hydrochlorothiazide and potassium",
+                "ATC/C03AX01": "hydrochlorothiazide, combinations",
+                "ATC/C03DB02": "NO_DEF",
+                "ATC/C03EA01": "hydrochlorothiazide and potassium-sparing agents",
+                "ATC/C03EA02": "trichlormethiazide and potassium-sparing agents",
+                "ATC/C03EA03": "epitizide and potassium-sparing agents",
+                "ATC/C03EA04": "altizide and potassium-sparing agents",
+                "ATC/C03EA05": "mebutizide and potassium-sparing agents",
+                "ATC/C03EA06": "chlortalidone and potassium-sparing agents",
+                "ATC/C03EA07": "cyclopenthiazide and potassium-sparing agents",
+                "ATC/C03EA12": "metolazone and potassium-sparing agents",
+                "ATC/C03EA13": "bendroflumethiazide and potassium-sparing agents",
+                "ATC/C03EA14": "butizide and potassium-sparing agents",
+                "ATC/C03EB01": "furosemide and potassium-sparing agents",
+                "ATC/C03EB02": "bumetanide and potassium-sparing agents",
+                "ATC/C07BA02": "oxprenolol and thiazides",
+                "ATC/C07BA05": "propranolol and thiazides",
+                "ATC/C07BA06": "timolol and thiazides",
+                "ATC/C07BA07": "sotalol and thiazides",
+                "ATC/C07BA12": "nadolol and thiazides",
+                "ATC/C07BA68": "metipranolol and thiazides, combinations",
+                "ATC/C07BB02": "metoprolol and thiazides",
+                "ATC/C07BB03": "atenolol and thiazides",
+                "ATC/C07BB04": "acebutolol and thiazides",
+                "ATC/C07BB06": "bevantolol and thiazides",
+                "ATC/C07BB07": "bisoprolol and thiazides",
+                "ATC/C07BB12": "nebivolol and thiazides",
+                "ATC/C07BB52": "metoprolol and thiazides, combinations",
+                "ATC/C07BG01": "labetalol and thiazides",
+                "ATC/C07CA02": "oxprenolol and other diuretics",
+                "ATC/C07CA03": "pindolol and other diuretics",
+                "ATC/C07CA17": "bopindolol and other diuretics",
+                "ATC/C07CA23": "penbutolol and other diuretics",
+                "ATC/C07CB02": "metoprolol and other diuretics",
+                "ATC/C07CB03": "atenolol and other diuretics",
+                "ATC/C07CB53": "atenolol and other diuretics, combinations",
+                "ATC/C07CG01": "labetalol and other diuretics",
+                "ATC/C07DA06": "timolol, thiazides and other diuretics",
+                "ATC/C07DB01": "atenolol, thiazides and other diuretics",
+                "ATC/C08DA51": "verapamil, combinations",
+                "ATC/C08GA01": "nifedipine and diuretics",
+                "ATC/C08GA02": "amlodipine and diuretics",
+                "ATC/C09BA01": "captopril and diuretics",
+                "ATC/C09BA02": "enalapril and diuretics",
+                "ATC/C09BA03": "lisinopril and diuretics",
+                "ATC/C09BA04": "perindopril and diuretics",
+                "ATC/C09BA05": "ramipril and diuretics",
+                "ATC/C09BA06": "quinapril and diuretics",
+                "ATC/C09BA07": "benazepril and diuretics",
+                "ATC/C09BA08": "cilazapril and diuretics",
+                "ATC/C09BA09": "fosinopril and diuretics",
+                "ATC/C09BA12": "delapril and diuretics",
+                "ATC/C09BA13": "moexipril and diuretics",
+                "ATC/C09BA15": "zofenopril and diuretics",
+                "ATC/C09BX03": "ramipril, amlodipine and hydrochlorothiazide",
+                "ATC/C09DA01": "losartan and diuretics",
+                "ATC/C09DA02": "eprosartan and diuretics",
+                "ATC/C09DA03": "valsartan and diuretics",
+                "ATC/C09DA04": "irbesartan and diuretics",
+                "ATC/C09DA06": "candesartan and diuretics",
+                "ATC/C09DA07": "telmisartan and diuretics",
+                "ATC/C09DA08": "olmesartan medoxomil and diuretics",
+                "ATC/C09DA09": "azilsartan medoxomil and diuretics",
+                "ATC/C09DA10": "fimasartan and diuretics",
+                "ATC/C09DX01": "valsartan, amlodipine and hydrochlorothiazide",
+                "ATC/C09DX03": "olmesartan medoxomil, amlodipine and hydrochlorothiazide",
+                "ATC/C09DX06": "candesartan, amlodipine and hydrochlorothiazide",
+                "ATC/C09DX07": "irbesartan, amlodipine and hydrochlorothiazide",
+                "ATC/C09XA52": "aliskiren and hydrochlorothiazide",
+                "ATC/C09XA54": "aliskiren, amlodipine and hydrochlorothiazide"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32103",
+            "date": "2009-11-23",
+            "observation": {
+                "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+                "ICD10CM/Z12.11": "Encounter for screening colonoscopy NOS",
+                "ICD10CM/Z12.4": "Encounter for screening pap smear for malignant neoplasm of cervix",
+                "ICD10CM/Z13.79": "Encounter for other screening for genetic and chromosomal anomalies"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32108",
+            "date": "2009-11-28",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "CPT4/99232": "SBSQ HOSPITAL CARE/DAY 25 MINUTES",
+                "ICD10CM/I74.5": "NO_DEF",
+                "ICD10CM/I87.2": "NO_DEF",
+                "ICD10CM/R10.811": "Right upper quadrant abdominal tenderness",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32114",
+            "date": "2009-12-04",
+            "observation": {
+                "CPT4/81003": "Automated urinalysis test",
+                "HCPCS/G0180": "Physician certification for medicare-covered home health services under a home health plan of care (patient not present), including contacts with home health agency and review of reports of patient status required by physicians to affirm the initial implementation of the plan of care that meets patient's needs, per certification period",
+                "ICD10CM/F01.51": "Vascular dementia with violent behavior",
+                "ICD10CM/F06.0": "Organic hallucinatory state (nonalcoholic)",
+                "ICD10CM/F43.20": "Adjustment disorder, unspecified",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32119",
+            "date": "2009-12-09",
+            "observation": {
+                "HCPCS/A6207": "Contact layer, sterile, more than 16 sq. in. but less than or equal to 48 sq. in., each dressing",
+                "ICD10CM/E11.65": "Type 2 diabetes mellitus with hyperglycemia",
+                "ICD10CM/G60.9": "NO_DEF",
+                "ICD10CM/L89.90": "Healing pressure ulcer of unspecified site NOS"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
+        },
+        {
+            "age in days": "32123",
+            "date": "2009-12-13",
+            "observation": {
+                "CPT4/70450": "CT scan head or brain",
+                "ICD10CM/I49.1": "Atrial premature beats",
+                "ICD10CM/I49.8": "Ectopic rhythm disorder"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32127",
+            "date": "2009-12-17",
+            "observation": {
+                "CPT4/11100": "NO_DEF",
+                "CPT4/99211": "OFFICE OUTPATIENT VISIT 5 MINUTES",
+                "HCPCS/G8553": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32130",
+            "date": "2009-12-20",
+            "observation": {
+                "CPT4/62264": "PRQ LYSIS EPIDURAL ADHESIONS MULT SESSIONS 1 DAY",
+                "ICD10CM/M46.00": "NO_DEF",
+                "ICD10CM/M47.819": "Spondylosis without myelopathy or radiculopathy, site unspecified",
+                "ICD10CM/M48.061": "Spinal stenosis, lumbar region NOS",
+                "ICD10CM/M51.26": "Other intervertebral disc displacement, lumbar region",
+                "ICD10CM/M51.36": "Other intervertebral disc degeneration, lumbar region"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32132",
+            "date": "2009-12-22",
+            "observation": {
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "HCPCS/A9552": "Fluorodeoxyglucose f-18 fdg, diagnostic, per study dose, up to 45 millicuries",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
+        },
+        {
+            "age in days": "32134",
+            "date": "2009-12-24",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "CPT4/99231": "SBSQ HOSPITAL CARE/DAY 15 MINUTES",
+                "CPT4/99238": "HOSPITAL DISCHARGE DAY MANAGEMENT 30 MIN/<",
+                "ICD10CM/E11.40": "Type 2 diabetes mellitus with diabetic neuropathy, unspecified",
+                "ICD10CM/E11.65": "Type 2 diabetes mellitus with hyperglycemia",
+                "ICD10CM/E66.9": "Obesity NOS",
+                "ICD10CM/L03.039": "Cellulitis of unspecified toe",
+                "ICD10CM/L60.1": "NO_DEF",
+                "ICD10CM/L97.509": "Non-pressure chronic ulcer of other part of unspecified foot with unspecified severity",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32138",
+            "date": "2009-12-28",
+            "observation": {
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "CPT4/99245": "OFFICE CONSULTATION NEW/ESTAB PATIENT 80 MIN",
+                "ICD10CM/M15.0": "Primary generalized (osteo)arthritis",
+                "ICD10CM/M48.061": "Spinal stenosis, lumbar region NOS",
+                "ICD10CM/M53.82": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32140",
+            "date": "2009-12-30",
+            "observation": {
+                "CPT4/11750": "EXCISION NAIL MATRIX PERMANENT REMOVAL",
+                "ICD10CM/L60.0": "NO_DEF",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32143",
+            "date": "2010-01-02",
+            "observation": {
+                "CPT4/93000": "ECG ROUTINE ECG W/LEAST 12 LDS W/I&R",
+                "CPT4/99307": "SBSQ NURSING FACILITY CARE/DAY E/M STABLE 10 MIN",
+                "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+                "ICD10CM/I25.811": "Atherosclerosis of native coronary artery of transplanted heart NOS",
+                "ICD10CM/Z95.1": "Presence of coronary artery bypass graft",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32153",
+            "date": "2010-01-12",
+            "observation": {
+                "CPT4/72100": "RADEX SPINE LUMBOSACRAL 2/3 VIEWS",
+                "ICD10CM/M53.1": "NO_DEF",
+                "ICD10CM/M54.89": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32167",
+            "date": "2010-01-26",
+            "observation": {
+                "CPT4/84443": "Thyroid stimulating hormone (TSH)",
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "HCPCS/G0283": "Electrical stimulation (unattended), to one or more areas for indication(s) other than wound care, as part of a therapy plan of care",
+                "ICD10CM/M15.0": "Primary generalized (osteo)arthritis",
+                "ICD10CM/M19.229": "Secondary osteoarthritis, unspecified elbow"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32182",
+            "date": "2010-02-10",
+            "observation": {
+                "CPT4/81003": "Automated urinalysis test",
+                "CPT4/87088": "Bacterial urine culture",
+                "CPT4/87186": "SUSCEPTIBLTY STDY ANTIMICRBIAL MICRO/AGAR DILUTJ",
+                "ICD10CM/N34.3": "NO_DEF",
+                "ICD10CM/N39.0": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32191",
+            "date": "2010-02-19",
+            "observation": {
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "CPT4/93010": "ECG ROUTINE ECG W/LEAST 12 LDS I&R ONLY",
+                "ICD10CM/G93.3": "NO_DEF",
+                "ICD10CM/I49.5": "Tachycardia-bradycardia syndrome",
+                "ICD10CM/I50.814": "Right heart failure due to left heart failure",
+                "ICD10CM/Z51.89": "Encounter for other specified aftercare",
+                "ICD10CM/Z79.01": "Long term (current) use of anticoagulants",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32205",
+            "date": "2010-03-05",
+            "observation": {
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/I11.9": "NO_DEF",
+                "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+                "ICD10CM/J44.1": "Decompensated COPD",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32214",
+            "date": "2010-03-14",
+            "observation": {
+                "CPT4/3342F": "MAMMO ASSESSMENT CAT BENIGN DOCD",
+                "CPT4/97001": "NO_DEF",
+                "HCPCS/G0202": "NO_DEF",
+                "HCPCS/G0283": "Electrical stimulation (unattended), to one or more areas for indication(s) other than wound care, as part of a therapy plan of care",
+                "ICD10CM/E11.21": "Type 2 diabetes mellitus with diabetic nephropathy",
+                "ICD10CM/E11.65": "Type 2 diabetes mellitus with hyperglycemia",
+                "ICD10CM/G93.41": "NO_DEF",
+                "ICD10CM/Z12.31": "Encounter for screening mammogram for malignant neoplasm of breast",
+                "ICD10CM/Z12.82": "Encounter for screening for malignant neoplasm of nervous system",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32219",
+            "date": "2010-03-19",
+            "observation": {
+                "CPT4/90658": "IIV3 VACCINE SPLIT VIRUS 0.5 ML DOSAGE IM USE",
+                "CPT4/96372": "Subcutaneous diagnostic injection",
+                "ICD10CM/Z20.9": "Contact with and (suspected) exposure to unspecified communicable disease",
+                "ICD10CM/Z23": "Encounter for immunization"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32235",
+            "date": "2010-04-04",
+            "observation": {
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "CPT4/97140": "Manual therapy techniques",
+                "ICD10CM/M65.20": "Calcific tendinitis, unspecified site",
+                "ICD10CM/M75.80": "Other shoulder lesions, unspecified shoulder"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32244",
+            "date": "2010-04-13",
+            "observation": {
+                "CPT4/98940": "CHIROPRACTIC MANIPULATIVE TX SPINAL 1-2 REGIONS",
+                "ICD10CM/M41.00": "NO_DEF",
+                "ICD10CM/M96.1": "NO_DEF",
+                "ICD10CM/M99.05": "Segmental and somatic dysfunction of pelvic region",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32246",
+            "date": "2010-04-15",
+            "observation": {
+                "CPT4/95811": "POLYSOM 6/>YRS SLEEP W/CPAP 4/> ADDL PARAM ATTND",
+                "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+                "ICD10CM/D46.22": "RAEB 2",
+                "ICD10CM/D64.9": "NO_DEF",
+                "ICD10CM/G47.33": "Obstructive sleep apnea hypopnea",
+                "ICD10CM/Q85.01": "Neurofibromatosis, type 1",
+                "ICD10CM/Z51.11": "Encounter for antineoplastic chemotherapy",
+                "ICD10CM/Z77.120": "Contact with and (suspected) exposure to mold (toxic)"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32247",
+            "date": "2010-04-16",
+            "observation": {
+                "CPT4/99205": "OFFICE OUTPATIENT NEW 60 MINUTES",
+                "ICD10CM/C83.54": "Lymphoblastic (diffuse) lymphoma, lymph nodes of axilla and upper limb",
+                "ICD10CM/C85.82": "Other specified types of non-Hodgkin lymphoma, intrathoracic lymph nodes"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32249",
+            "date": "2010-04-18",
+            "observation": {
+                "CPT4/98941": "CHIROPRACTIC MANIPULATIVE TX SPINAL 3-4 REGIONS",
+                "ICD10CM/M43.27": "Fusion of spine, lumbosacral region",
+                "ICD10CM/M51.36": "Other intervertebral disc degeneration, lumbar region",
+                "ICD10CM/M93.90": "Osteochondropathy, unspecified of unspecified site",
+                "ICD10CM/M99.05": "Segmental and somatic dysfunction of pelvic region",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32253",
+            "date": "2010-04-22",
+            "observation": {
+                "CPT4/82491": "NO_DEF",
+                "CPT4/92250": "Photography of the retina",
+                "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+                "ICD10CM/E78.00": "(Pure) hypercholesterolemia NOS",
+                "ICD10CM/G47.30": "Sleep apnea NOS",
+                "ICD10CM/H02.839": "Dermatochalasis of unspecified eye, unspecified eyelid",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32254",
+            "date": "2010-04-23",
+            "observation": {
+                "ATC/M03BX08": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32259",
+            "date": "2010-04-28",
+            "observation": {
+                "CPT4/11101": "NO_DEF",
+                "CPT4/72052": "RADEX SPINE CERVICAL 6 OR MORE VIEWS",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "HCPCS/G8445": "NO_DEF",
+                "ICD10CM/M17.10": "Unilateral primary osteoarthritis, unspecified knee",
+                "ICD10CM/M19.90": "Unspecified osteoarthritis, unspecified site",
+                "ICD10CM/M47.812": "Spondylosis without myelopathy or radiculopathy, cervical region",
+                "ICD10CM/M48.02": "NO_DEF"
+            },
+            "observation with values": {
+                "Visit/OP-0.0": "NO_DEF"
+            }
+        },
+        {
+            "age in days": "32267",
+            "date": "2010-05-06",
+            "observation": {
+                "CPT4/73140": "X-ray of finger",
+                "CPT4/90732": "PPSV23 VACCINE 2 YRS OR OLDER FOR SUBQ/IM USE",
+                "CPT4/96372": "Subcutaneous diagnostic injection",
+                "CPT4/99204": "OFFICE OUTPATIENT NEW 45 MINUTES",
+                "HCPCS/G8553": "NO_DEF",
+                "ICD10CM/M47.817": "Spondylosis without myelopathy or radiculopathy, lumbosacral region",
+                "ICD10CM/M48.061": "Spinal stenosis, lumbar region NOS",
+                "ICD10CM/M51.26": "Other intervertebral disc displacement, lumbar region",
+                "ICD10CM/M54.5": "Lumbago NOS",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32275",
+            "date": "2010-05-14",
+            "observation": {
+                "CPT4/97110": "THERAPEUTIC PX 1/> AREAS EACH 15 MIN EXERCISES",
+                "ICD10CM/M15.0": "Primary generalized (osteo)arthritis",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32277",
+            "date": "2010-05-16",
+            "observation": {
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "CPT4/81002": "Urinalysis, manual test",
+                "CPT4/84550": "Uric acid; blood",
+                "ICD10CM/M15.0": "Primary generalized (osteo)arthritis",
+                "ICD10CM/M19.019": "Primary osteoarthritis, unspecified shoulder",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32284",
+            "date": "2010-05-23",
+            "observation": {
+                "CPT4/96415": "Infusion of chemotherapy into a vein",
+                "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+                "HCPCS/J7050": "Infusion, normal saline solution, 250 cc",
+                "ICD10CM/M06.9": "NO_DEF",
+                "ICD10CM/M08.40": "Pauciarticular juvenile rheumatoid arthritis, unspecified site"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32296",
+            "date": "2010-06-04",
+            "observation": {
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "CPT4/80053": "Measurement of albumin",
+                "CPT4/85025": "Automated platelet count",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "HCPCS/G8447": "NO_DEF",
+                "ICD10CM/H60.60": "Unspecified chronic otitis externa, unspecified ear",
+                "ICD10CM/H65.20": "Chronic serous otitis media, unspecified ear",
+                "ICD10CM/H66.009": "Acute suppurative otitis media without spontaneous rupture of ear drum, unspecified ear",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32300",
+            "date": "2010-06-08",
+            "observation": {
+                "CPT4/93613": "INTRACARDIAC ELECTROPHYSIOLOGIC 3D MAPPING",
+                "CPT4/93618": "INDUCTION ARRHYTHMIA ELECTRICAL PACING",
+                "CPT4/93620": "COMPRE ELECTROPHYSIOLOGIC ARRHYTHMIA INDUCTION",
+                "CPT4/93621": "COMPRE ELECTROPHYSIOL XM W/LEFT ATRIAL PACNG/REC",
+                "CPT4/93662": "Ultrasound evaluation of heart blood vessel",
+                "ICD10CM/I47.1": "Nodal (paroxysmal) tachycardia",
+                "ICD10CM/I49.5": "Tachycardia-bradycardia syndrome"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32303",
+            "date": "2010-06-11",
+            "observation": {
+                "CPT4/98940": "CHIROPRACTIC MANIPULATIVE TX SPINAL 1-2 REGIONS",
+                "ICD10CM/M42.00": "NO_DEF",
+                "ICD10CM/M99.05": "Segmental and somatic dysfunction of pelvic region",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32322",
+            "date": "2010-06-30",
+            "observation": {
+                "CPT4/51741": "COMPLEX UROFLOMETRY",
+                "CPT4/52235": "CYSTOURETHROSCOPY W/DEST &/RMVL MED BLADDER TUM",
+                "ICD10CM/C67.0": "NO_DEF",
+                "ICD10CM/C67.9": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32325",
+            "date": "2010-07-03",
+            "observation": {
+                "CPT4/99285": "EMERGENCY DEPT VISIT HIGH SEVERITY&THREAT FUNCJ",
+                "ICD10CM/S33.8XXA": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32340",
+            "date": "2010-07-18",
+            "observation": {
+                "CPT4/17110": "Destruction of benign lesion",
+                "CPT4/3075F": "MOST RECENT SYSTOLIC BLOOD PRESS 130-139MM HG",
+                "CPT4/94760": "NONINVASIVE EAR/PULSE OXIMETRY SINGLE DETER",
+                "CPT4/98941": "CHIROPRACTIC MANIPULATIVE TX SPINAL 3-4 REGIONS",
+                "HCPCS/J3301": "Injection, triamcinolone acetonide, not otherwise specified, 10 mg",
+                "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+                "ICD10CM/G89.11": "Acute pain due to trauma",
+                "ICD10CM/S13.4XXA": "Sprain of ligaments of cervical spine, initial encounter",
+                "ICD10CM/S23.420A": "Sprain of sternoclavicular (joint) (ligament), initial encounter"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32346",
+            "date": "2010-07-24",
+            "observation": {
+                "CPT4/1000F": "TOBACCO USE ASSESSED",
+                "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+                "CPT4/99222": "INITIAL HOSPITAL CARE/DAY 50 MINUTES",
+                "HCPCS/G8445": "NO_DEF",
+                "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32373",
+            "date": "2010-08-20",
+            "observation": {
+                "CPT4/80061": "LIPID PANEL",
+                "CPT4/84443": "Thyroid stimulating hormone (TSH)",
+                "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+                "ICD10CM/M51.34": "Other intervertebral disc degeneration, thoracic region",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32374",
+            "date": "2010-08-21",
+            "observation": {
+                "CPT4/11721": "Debridement of 6 or more nails",
+                "ICD10CM/B35.1": "Ringworm of nails",
+                "ICD10CM/I70.209": "Unspecified atherosclerosis of native arteries of extremities, unspecified extremity",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32377",
+            "date": "2010-08-24",
+            "observation": {
+                "CPT4/99202": "OFFICE OUTPATIENT NEW 20 MINUTES",
+                "ICD10CM/L66.3": "NO_DEF",
+                "ICD10CM/R21": "rash NOS"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32387",
+            "date": "2010-09-03",
+            "observation": {
+                "CPT4/71250": "CT scan chest",
+                "CPT4/82947": "Blood glucose (sugar) level",
+                "ICD10CM/J06.9": "Upper respiratory infection NOS",
+                "ICD10CM/N18.3": "Chronic kidney disease, stage 3 (moderate)",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32388",
+            "date": "2010-09-04",
+            "observation": {
+                "CPT4/99204": "OFFICE OUTPATIENT NEW 45 MINUTES",
+                "ICD10CM/M17.9": "Osteoarthritis of knee, unspecified",
+                "ICD10CM/Z87.39": "Personal history of other diseases of the musculoskeletal system and connective tissue"
+            },
+            "observation with values": {}
+        },
+        {
+            "age in days": "32391",
+            "date": "2010-09-07",
+            "observation": {
+                "CPT4/73000": "X-ray of clavicle",
+                "CPT4/97035": "Application of ultrasound modality",
+                "CPT4/97140": "Manual therapy techniques",
+                "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+                "ICD10CM/M25.50": "Pain in unspecified joint",
+                "ICD10CM/M25.569": "Pain in unspecified knee",
+                "ICD10CM/M51.36": "Other intervertebral disc degeneration, lumbar region",
+                "None/No matching concept": "NO_DEF"
+            },
+            "observation with values": {}
+        }
+    ],
+    "patient_id": 6
 }

--- a/test_patient.json
+++ b/test_patient.json
@@ -1,0 +1,909 @@
+{
+    "day 0": {
+        "age in days": "0",
+        "date": "1943-01-01",
+        "observation": {
+            "Ethnicity/Not Hispanic": "NO_DEF",
+            "Gender/M": "NO_DEF",
+            "Race/5": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 1": {
+        "age in days": "24018",
+        "date": "2008-10-04",
+        "observation": {
+            "CPT4/29405": "Application of below knee to toes cast",
+            "CPT4/83036": "HEMOGLOBIN GLYCOSYLATED A1C",
+            "ICD10CM/G57.90": "Unspecified mononeuropathy of unspecified lower limb",
+            "ICD10CM/S82.839B": "Other fracture of upper and lower end of unspecified fibula, initial encounter for open fracture type I or II",
+            "ICD10CM/S92.403A": "NO_DEF",
+            "ICD10CM/Z23": "Encounter for immunization"
+        },
+        "observation with values": []
+    },
+    "day 10": {
+        "age in days": "24123",
+        "date": "2009-01-17",
+        "observation": {
+            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+            "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+            "ICD10CM/R07.2": "NO_DEF",
+            "ICD10CM/Z23": "Encounter for immunization",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 11": {
+        "age in days": "24133",
+        "date": "2009-01-27",
+        "observation": {
+            "ATC/D01AE54": "undecylenic acid, combinations",
+            "ATC/D07XA01": "NO_DEF",
+            "ATC/D07XA02": "NO_DEF",
+            "ATC/D07XB05": "NO_DEF",
+            "ATC/D08AC52": "chlorhexidine, combinations",
+            "ATC/D08AX05": "isopropanol",
+            "ATC/D08AX53": "propanol, combinations",
+            "ATC/S02AA30": "NO_DEF",
+            "ATC/S03AA30": "antiinfectives, combinations"
+        },
+        "observation with values": []
+    },
+    "day 12": {
+        "age in days": "24135",
+        "date": "2009-01-29",
+        "observation": {
+            "ATC/N07AA51": "neostigmine, combinations",
+            "ATC/N07AX01": "NO_DEF",
+            "ATC/R01BA53": "NO_DEF",
+            "ATC/S01EA51": "epinephrine, combinations",
+            "ATC/S01EB01": "NO_DEF",
+            "ATC/S01EB51": "pilocarpine, combinations",
+            "ATC/S01ED51": "timolol, combinations",
+            "ATC/S01ED52": "betaxolol, combinations",
+            "ATC/S01GA51": "naphazoline, combinations",
+            "ATC/S01KA51": "hyaluronic acid, combinations"
+        },
+        "observation with values": []
+    },
+    "day 13": {
+        "age in days": "24173",
+        "date": "2009-03-08",
+        "observation": {
+            "CPT4/99254": "INITIAL INPATIENT CONSULT NEW/ESTAB PT 80 MIN",
+            "ICD10CM/R11.0": "Nausea NOS",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 14": {
+        "age in days": "24179",
+        "date": "2009-03-14",
+        "observation": {
+            "CPT4/72194": "CT PELVIS W/O & W/CONTRAST MATERIAL",
+            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+            "ICD10CM/R10.9": "Unspecified abdominal pain"
+        },
+        "observation with values": []
+    },
+    "day 15": {
+        "age in days": "24189",
+        "date": "2009-03-24",
+        "observation": {
+            "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+            "ICD10CM/D56.8": "Mixed thalassemia",
+            "ICD10CM/D63.8": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 16": {
+        "age in days": "24195",
+        "date": "2009-03-30",
+        "observation": {
+            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+            "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+            "ICD10CM/I63.50": "Cerebral infarction due to unspecified occlusion or stenosis of unspecified cerebral artery",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 17": {
+        "age in days": "24197",
+        "date": "2009-04-01",
+        "observation": {
+            "ATC/C03AX01": "hydrochlorothiazide, combinations",
+            "ATC/C09AA03": "NO_DEF",
+            "ATC/C09BA03": "lisinopril and diuretics",
+            "ATC/C09BB03": "lisinopril and amlodipine",
+            "ATC/C10BX07": "rosuvastatin, amlodipine and lisinopril"
+        },
+        "observation with values": []
+    },
+    "day 18": {
+        "age in days": "24208",
+        "date": "2009-04-12",
+        "observation": {
+            "ICD10CM/C78.00": "Secondary malignant neoplasm of unspecified lung",
+            "ICD10CM/C79.89": "NO_DEF",
+            "ICD10CM/E87.6": "Potassium [K] deficiency",
+            "ICD10CM/M15.9": "Generalized osteoarthritis NOS",
+            "ICD10CM/N18.3": "Chronic kidney disease, stage 3 (moderate)",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": [
+            "Visit/IP-6.0"
+        ]
+    },
+    "day 19": {
+        "age in days": "24211",
+        "date": "2009-04-15",
+        "observation": {
+            "CPT4/88175": "Cytopathology on vaginal specimen",
+            "CPT4/99215": "OFFICE OUTPATIENT VISIT 40 MINUTES",
+            "ICD10CM/E03.9": "Myxedema NOS",
+            "ICD10CM/E78.00": "(Pure) hypercholesterolemia NOS",
+            "ICD10CM/I25.10": "Atherosclerotic heart disease NOS",
+            "ICD10CM/Z12.4": "Encounter for screening pap smear for malignant neoplasm of cervix",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 2": {
+        "age in days": "24022",
+        "date": "2008-10-08",
+        "observation": {
+            "CPT4/71010": "NO_DEF",
+            "CPT4/76700": "Ultrasound of abdomen",
+            "ICD10CM/I10": "hypertension (arterial) (benign) (essential) (malignant) (primary) (systemic)",
+            "ICD10CM/R10.10": "Upper abdominal pain, unspecified",
+            "ICD10CM/R10.813": "Right lower quadrant abdominal tenderness",
+            "ICD10CM/R10.9": "Unspecified abdominal pain",
+            "ICD10CM/R11.2": "Nausea with vomiting, unspecified"
+        },
+        "observation with values": []
+    },
+    "day 20": {
+        "age in days": "24237",
+        "date": "2009-05-11",
+        "observation": {
+            "CPT4/99222": "INITIAL HOSPITAL CARE/DAY 50 MINUTES",
+            "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+            "ICD10CM/I62.9": "Nontraumatic intracranial hemorrhage, unspecified",
+            "ICD10CM/N18.9": "Chronic uremia NOS",
+            "ICD10CM/Z49.01": "Toilet or cleansing of renal dialysis catheter",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 21": {
+        "age in days": "24242",
+        "date": "2009-05-16",
+        "observation": {
+            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+            "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+            "ICD10CM/N18.9": "Chronic uremia NOS",
+            "ICD10CM/Z49.32": "Encounter for peritoneal equilibration test",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 22": {
+        "age in days": "24259",
+        "date": "2009-06-02",
+        "observation": {
+            "CPT4/80048": "Measurement of creatinine",
+            "CPT4/80061": "LIPID PANEL",
+            "CPT4/80076": "HEPATIC FUNCTION PANEL",
+            "CPT4/82306": "Vitamin D-3 level",
+            "CPT4/84075": "Phosphatase, alkaline",
+            "CPT4/85025": "Automated platelet count",
+            "CPT4/85610": "PROTHROMBIN TIME",
+            "CPT4/87088": "Bacterial urine culture",
+            "CPT4/96372": "Subcutaneous diagnostic injection",
+            "ICD10CM/F73": "IQ level below 20-25",
+            "ICD10CM/I48.91": "Unspecified atrial fibrillation",
+            "ICD10CM/Z48.02": "Encounter for removal of sutures",
+            "ICD10CM/Z79.01": "Long term (current) use of anticoagulants",
+            "ICD10CM/Z79.84": "Long term (current) use of oral hypoglycemic drugs",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": [
+            "Visit/OP-0.0"
+        ]
+    },
+    "day 23": {
+        "age in days": "24262",
+        "date": "2009-06-05",
+        "observation": {
+            "CPT4/99284": "EMERGENCY DEPARTMENT VISIT HIGH/URGENT SEVERITY",
+            "ICD10CM/M46.1": "NO_DEF",
+            "ICD10CM/M50.30": "Other cervical disc degeneration, unspecified cervical region",
+            "ICD10CM/M54.5": "Lumbago NOS",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 24": {
+        "age in days": "24278",
+        "date": "2009-06-21",
+        "observation": {
+            "CPT4/90862": "NO_DEF",
+            "ICD10CM/F20.0": "NO_DEF",
+            "ICD10CM/F20.2": "Schizophrenic catalepsy"
+        },
+        "observation with values": []
+    },
+    "day 25": {
+        "age in days": "24280",
+        "date": "2009-06-23",
+        "observation": {
+            "CPT4/71101": "RADEX RIBS UNI W/POSTEROANT CH MINIMUM 3 VIEWS",
+            "CPT4/78480": "NO_DEF",
+            "CPT4/94060": "BRNCDILAT RSPSE SPMTRY PRE&POST-BRNCDILAT ADMN",
+            "ICD10CM/S69.80XA": "Other specified injuries of unspecified wrist, hand and finger(s), initial encounter",
+            "ICD10CM/W22.09XA": "Striking against other stationary object, initial encounter",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": [
+            "Visit/OP-0.0"
+        ]
+    },
+    "day 26": {
+        "age in days": "24283",
+        "date": "2009-06-26",
+        "observation": {
+            "ATC/G04CA03": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 27": {
+        "age in days": "24290",
+        "date": "2009-07-03",
+        "observation": {
+            "CPT4/77280": "THER RAD SIMULAJ-AIDED FIELD SETTING SIMPLE",
+            "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+            "HCPCS/G8447": "NO_DEF",
+            "ICD10CM/I47.2": "NO_DEF",
+            "ICD10CM/I49.9": "Arrhythmia (cardiac) NOS",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 28": {
+        "age in days": "24303",
+        "date": "2009-07-16",
+        "observation": {
+            "HCPCS/A0427": "Ambulance service, advanced life support, emergency transport, level 1 (als 1 - emergency)",
+            "ICD10CM/K85.90": "Acute pancreatitis without necrosis or infection, unspecified",
+            "ICD10CM/R10.815": "Periumbilic abdominal tenderness",
+            "ICD10CM/R10.84": "NO_DEF",
+            "ICD10CM/R11.10": "Vomiting, unspecified",
+            "ICD10CM/R63.4": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 29": {
+        "age in days": "24318",
+        "date": "2009-07-31",
+        "observation": {
+            "CPT4/80048": "Measurement of creatinine",
+            "CPT4/80053": "Measurement of albumin",
+            "CPT4/80061": "LIPID PANEL",
+            "CPT4/83036": "HEMOGLOBIN GLYCOSYLATED A1C",
+            "CPT4/84439": "Thyroxine; free",
+            "CPT4/84443": "Thyroid stimulating hormone (TSH)",
+            "CPT4/84460": "Liver enzyme (SGPT), level",
+            "CPT4/85025": "Automated platelet count",
+            "HCPCS/G0103": "Prostate cancer screening; prostate specific antigen test (psa)",
+            "ICD10CM/E07.9": "NO_DEF",
+            "ICD10CM/E11.9": "Type 2 diabetes mellitus without complications",
+            "ICD10CM/E67.8": "NO_DEF",
+            "ICD10CM/I49.3": "NO_DEF",
+            "ICD10CM/R39.12": "Weak urinary steam",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 3": {
+        "age in days": "24023",
+        "date": "2008-10-09",
+        "observation": {
+            "CPT4/20610": "Injection of major joint",
+            "CPT4/71020": "NO_DEF",
+            "CPT4/76514": "OPHTHALMIC US DX CORNEAL PACHYMETRY UNI/BI",
+            "CPT4/85025": "Automated platelet count",
+            "CPT4/96372": "Subcutaneous diagnostic injection",
+            "CPT4/99000": "HANDLG&/OR CONVEY OF SPEC FOR TR OFFICE TO LAB",
+            "HCPCS/G8445": "NO_DEF",
+            "HCPCS/G8447": "NO_DEF",
+            "HCPCS/J1200": "Injection, diphenhydramine hcl, up to 50 mg",
+            "ICD10CM/D64.9": "NO_DEF",
+            "ICD10CM/E03.9": "Myxedema NOS",
+            "ICD10CM/E16.3": "Hyperplasia of pancreatic endocrine cells with glucagon excess",
+            "ICD10CM/F41.9": "Anxiety NOS",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 30": {
+        "age in days": "24329",
+        "date": "2009-08-11",
+        "observation": {
+            "CPT4/84402": "Testosterone; free",
+            "CPT4/90862": "NO_DEF",
+            "ICD10CM/F31.81": "Bipolar disorder, type 2",
+            "ICD10CM/F32.4": "Major depressive disorder, single episode, in partial remission",
+            "ICD10CM/F42.2": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 31": {
+        "age in days": "24342",
+        "date": "2009-08-24",
+        "observation": {
+            "CPT4/72148": "MRI scan of lower spinal canal",
+            "ICD10CM/M47.819": "Spondylosis without myelopathy or radiculopathy, site unspecified",
+            "ICD10CM/M48.061": "Spinal stenosis, lumbar region NOS",
+            "ICD10CM/M51.06": "Intervertebral disc disorders with myelopathy, lumbar region",
+            "ICD10CM/M62.81": "Muscle weakness (generalized)",
+            "ICD10CM/R19.09": "Other intra-abdominal and pelvic swelling, mass and lump"
+        },
+        "observation with values": []
+    },
+    "day 32": {
+        "age in days": "24349",
+        "date": "2009-08-31",
+        "observation": {
+            "ICD10CM/F06.0": "Organic hallucinatory state (nonalcoholic)",
+            "ICD10CM/K59.00": "Constipation, unspecified",
+            "ICD10CM/N81.5": "NO_DEF",
+            "ICD10CM/Z79.82": "Long term (current) use of aspirin",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": [
+            "Visit/IP-2.0"
+        ]
+    },
+    "day 33": {
+        "age in days": "24366",
+        "date": "2009-09-17",
+        "observation": {
+            "ICD10CM/F10.20": "Alcohol use disorder, severe",
+            "ICD10CM/F32.2": "Major depressive disorder, single episode, severe without psychotic features",
+            "ICD10CM/G40.901": "Epilepsy, unspecified, not intractable, with status epilepticus",
+            "ICD10CM/G47.33": "Obstructive sleep apnea hypopnea",
+            "ICD10CM/M12.9": "NO_DEF",
+            "ICD10CM/Z91.19": "Nonadherence to medical treatment"
+        },
+        "observation with values": [
+            "Visit/IP-3.0"
+        ]
+    },
+    "day 34": {
+        "age in days": "24380",
+        "date": "2009-10-01",
+        "observation": {
+            "CPT4/99212": "OFFICE OUTPATIENT VISIT 10 MINUTES",
+            "ICD10CM/A01.00": "Typhoid fever, unspecified",
+            "ICD10CM/A08.8": "NO_DEF",
+            "ICD10CM/R68.0": "NO_DEF",
+            "ICD10CM/Z79.4": "Long term (current) use of insulin"
+        },
+        "observation with values": []
+    },
+    "day 35": {
+        "age in days": "24384",
+        "date": "2009-10-05",
+        "observation": {
+            "CPT4/72131": "CT scan of lower spine",
+            "ICD10CM/M15.0": "Primary generalized (osteo)arthritis",
+            "ICD10CM/M25.519": "Pain in unspecified shoulder",
+            "ICD10CM/M51.36": "Other intervertebral disc degeneration, lumbar region",
+            "ICD10CM/M51.9": "Unspecified thoracic, thoracolumbar and lumbosacral intervertebral disc disorder",
+            "ICD10CM/M54.5": "Lumbago NOS"
+        },
+        "observation with values": []
+    },
+    "day 36": {
+        "age in days": "24388",
+        "date": "2009-10-09",
+        "observation": {
+            "ATC/A02BX71": "carbenoxolone, combinations with psycholeptics",
+            "ATC/A02BX77": "gefarnate, combinations with psycholeptics",
+            "ATC/A03CA01": "isopropamide and psycholeptics",
+            "ATC/A03CA02": "clidinium and psycholeptics",
+            "ATC/A03CA03": "oxyphencyclimine and psycholeptics",
+            "ATC/A03CA04": "otilonium bromide and psycholeptics",
+            "ATC/A03CA05": "glycopyrronium bromide and psycholeptics",
+            "ATC/A03CA06": "bevonium and psycholeptics",
+            "ATC/A03CA07": "ambutonium and psycholeptics",
+            "ATC/A03CA08": "diphemanil and psycholeptics",
+            "ATC/A03CA09": "pipenzolate and psycholeptics",
+            "ATC/A03CA30": "emepronium and psycholeptics",
+            "ATC/A03CA34": "propantheline and psycholeptics",
+            "ATC/A03CB01": "methylscopolamine and psycholeptics",
+            "ATC/A03CB02": "belladonna total alkaloids and psycholeptics",
+            "ATC/A03CB03": "atropine and psycholeptics",
+            "ATC/A03CB04": "homatropine methylbromide and psycholeptics",
+            "ATC/A03CB31": "hyoscyamine and psycholeptics",
+            "ATC/C01BA71": "quinidine, combinations with psycholeptics",
+            "ATC/C01DA70": "organic nitrates in combination with psycholeptics",
+            "ATC/C02LA71": "reserpine and diuretics, combinations with psycholeptics",
+            "ATC/C02LG73": "picodralazine and diuretics, combinations with psycholeptics",
+            "ATC/C03BA82": "clorexolone, combinations with psycholeptics",
+            "ATC/M03BA71": "phenprobamate, combinations with psycholeptics",
+            "ATC/M03BA72": "carisoprodol, combinations with psycholeptics",
+            "ATC/M03BA73": "methocarbamol, combinations with psycholeptics",
+            "ATC/M03BB72": "chlormezanone, combinations with psycholeptics",
+            "ATC/M03BB73": "chlorzoxazone, combinations with psycholeptics",
+            "ATC/M09AA72": "quinine, combinations with psycholeptics",
+            "ATC/N02AB72": "pethidine, combinations with psycholeptics",
+            "ATC/N02AC74": "dextropropoxyphene, combinations with psycholeptics",
+            "ATC/N02BA71": "acetylsalicylic acid, combinations with psycholeptics",
+            "ATC/N02BA75": "salicylamide, combinations with psycholeptics",
+            "ATC/N02BA77": "ethenzamide, combinations with psycholeptics",
+            "ATC/N02BA79": "dipyrocetyl, combinations with psycholeptics",
+            "ATC/N02BB71": "phenazone, combinations with psycholeptics",
+            "ATC/N02BB72": "metamizole sodium, combinations with psycholeptics",
+            "ATC/N02BB73": "aminophenazone, combinations with psycholeptics",
+            "ATC/N02BB74": "propyphenazone, combinations with psycholeptics",
+            "ATC/N02BE71": "paracetamol, combinations with psycholeptics",
+            "ATC/N02BE73": "phenacetin, combinations with psycholeptics",
+            "ATC/N02BE74": "bucetin, combinations with psycholeptics",
+            "ATC/N02CA72": "ergotamine, combinations with psycholeptics",
+            "ATC/N05AB02": "NO_DEF",
+            "ATC/N06CA01": "amitriptyline and psycholeptics",
+            "ATC/N06CA02": "melitracen and psycholeptics",
+            "ATC/N06CA03": "fluoxetine and psycholeptics",
+            "ATC/R03DA74": "theophylline, combinations with psycholeptics"
+        },
+        "observation with values": []
+    },
+    "day 37": {
+        "age in days": "24408",
+        "date": "2009-10-29",
+        "observation": {
+            "CPT4/99223": "INITIAL HOSPITAL CARE/DAY 70 MINUTES",
+            "ICD10CM/K56.50": "Intestinal adhesions with obstruction NOS",
+            "ICD10CM/K56.600": "Incomplete intestinal obstruction, NOS"
+        },
+        "observation with values": []
+    },
+    "day 38": {
+        "age in days": "24417",
+        "date": "2009-11-07",
+        "observation": {
+            "ATC/A02BX71": "carbenoxolone, combinations with psycholeptics",
+            "ATC/A02BX77": "gefarnate, combinations with psycholeptics",
+            "ATC/A03CA01": "isopropamide and psycholeptics",
+            "ATC/A03CA02": "clidinium and psycholeptics",
+            "ATC/A03CA03": "oxyphencyclimine and psycholeptics",
+            "ATC/A03CA04": "otilonium bromide and psycholeptics",
+            "ATC/A03CA05": "glycopyrronium bromide and psycholeptics",
+            "ATC/A03CA06": "bevonium and psycholeptics",
+            "ATC/A03CA07": "ambutonium and psycholeptics",
+            "ATC/A03CA08": "diphemanil and psycholeptics",
+            "ATC/A03CA09": "pipenzolate and psycholeptics",
+            "ATC/A03CA30": "emepronium and psycholeptics",
+            "ATC/A03CA34": "propantheline and psycholeptics",
+            "ATC/A03CB01": "methylscopolamine and psycholeptics",
+            "ATC/A03CB02": "belladonna total alkaloids and psycholeptics",
+            "ATC/A03CB03": "atropine and psycholeptics",
+            "ATC/A03CB04": "homatropine methylbromide and psycholeptics",
+            "ATC/A03CB31": "hyoscyamine and psycholeptics",
+            "ATC/C01BA71": "quinidine, combinations with psycholeptics",
+            "ATC/C01DA70": "organic nitrates in combination with psycholeptics",
+            "ATC/C02LA71": "reserpine and diuretics, combinations with psycholeptics",
+            "ATC/C02LG73": "picodralazine and diuretics, combinations with psycholeptics",
+            "ATC/C03BA82": "clorexolone, combinations with psycholeptics",
+            "ATC/M03BA71": "phenprobamate, combinations with psycholeptics",
+            "ATC/M03BA72": "carisoprodol, combinations with psycholeptics",
+            "ATC/M03BA73": "methocarbamol, combinations with psycholeptics",
+            "ATC/M03BB72": "chlormezanone, combinations with psycholeptics",
+            "ATC/M03BB73": "chlorzoxazone, combinations with psycholeptics",
+            "ATC/M09AA72": "quinine, combinations with psycholeptics",
+            "ATC/N02AB72": "pethidine, combinations with psycholeptics",
+            "ATC/N02AC74": "dextropropoxyphene, combinations with psycholeptics",
+            "ATC/N02BA71": "acetylsalicylic acid, combinations with psycholeptics",
+            "ATC/N02BA75": "salicylamide, combinations with psycholeptics",
+            "ATC/N02BA77": "ethenzamide, combinations with psycholeptics",
+            "ATC/N02BA79": "dipyrocetyl, combinations with psycholeptics",
+            "ATC/N02BB71": "phenazone, combinations with psycholeptics",
+            "ATC/N02BB72": "metamizole sodium, combinations with psycholeptics",
+            "ATC/N02BB73": "aminophenazone, combinations with psycholeptics",
+            "ATC/N02BB74": "propyphenazone, combinations with psycholeptics",
+            "ATC/N02BE71": "paracetamol, combinations with psycholeptics",
+            "ATC/N02BE73": "phenacetin, combinations with psycholeptics",
+            "ATC/N02BE74": "bucetin, combinations with psycholeptics",
+            "ATC/N02CA72": "ergotamine, combinations with psycholeptics",
+            "ATC/N05AB06": "NO_DEF",
+            "ATC/N06CA01": "amitriptyline and psycholeptics",
+            "ATC/N06CA02": "melitracen and psycholeptics",
+            "ATC/N06CA03": "fluoxetine and psycholeptics",
+            "ATC/R03DA74": "theophylline, combinations with psycholeptics"
+        },
+        "observation with values": []
+    },
+    "day 39": {
+        "age in days": "24421",
+        "date": "2009-11-11",
+        "observation": {
+            "CPT4/93010": "ECG ROUTINE ECG W/LEAST 12 LDS I&R ONLY",
+            "ICD10CM/I49.3": "NO_DEF",
+            "ICD10CM/I49.8": "Ectopic rhythm disorder"
+        },
+        "observation with values": []
+    },
+    "day 4": {
+        "age in days": "24034",
+        "date": "2008-10-20",
+        "observation": {
+            "CPT4/99231": "SBSQ HOSPITAL CARE/DAY 15 MINUTES",
+            "ICD10CM/R31.0": "NO_DEF",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 40": {
+        "age in days": "24442",
+        "date": "2009-12-02",
+        "observation": {
+            "CPT4/99214": "OFFICE OUTPATIENT VISIT 25 MINUTES",
+            "ICD10CM/C80.1": "Cancer NOS",
+            "ICD10CM/Z51.11": "Encounter for antineoplastic chemotherapy"
+        },
+        "observation with values": []
+    },
+    "day 41": {
+        "age in days": "24446",
+        "date": "2009-12-06",
+        "observation": {
+            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+            "ICD10CM/R41.2": "NO_DEF",
+            "ICD10CM/Z92.25": "Personal history of immunosupression therapy",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 42": {
+        "age in days": "24494",
+        "date": "2010-01-23",
+        "observation": {
+            "CPT4/99309": "SBSQ NURSING FACIL CARE/DAY NEW PROBLEM 25 MIN",
+            "ICD10CM/G47.419": "Narcolepsy NOS",
+            "ICD10CM/G57.90": "Unspecified mononeuropathy of unspecified lower limb",
+            "ICD10CM/I87.2": "NO_DEF",
+            "ICD10CM/M79.609": "Pain in limb NOS",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 43": {
+        "age in days": "24521",
+        "date": "2010-02-19",
+        "observation": {
+            "CPT4/2027F": "OPTIC NERVE HEAD EVALUATION PERFORMED",
+            "CPT4/92014": "OPHTH MEDICAL XM&EVAL COMPRHNSV ESTAB PT 1/>",
+            "ICD10CM/E10.9": "Type 1 diabetes mellitus without complications",
+            "ICD10CM/H25.049": "Posterior subcapsular polar age-related cataract, unspecified eye",
+            "ICD10CM/H25.10": "Age-related nuclear cataract, unspecified eye",
+            "ICD10CM/H26.229": "Cataract secondary to ocular disorders (degenerative) (inflammatory), unspecified eye",
+            "ICD10CM/H43.819": "Vitreous degeneration, unspecified eye"
+        },
+        "observation with values": []
+    },
+    "day 44": {
+        "age in days": "24525",
+        "date": "2010-02-23",
+        "observation": {
+            "CPT4/84460": "Liver enzyme (SGPT), level",
+            "CPT4/99233": "SBSQ HOSPITAL CARE/DAY 35 MINUTES",
+            "ICD10CM/M10.00": "Idiopathic gout, unspecified site",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 45": {
+        "age in days": "24526",
+        "date": "2010-02-24",
+        "observation": {
+            "CPT4/99222": "INITIAL HOSPITAL CARE/DAY 50 MINUTES",
+            "HCPCS/Q9967": "Low osmolar contrast material, 300-399 mg/ml iodine concentration, per ml",
+            "ICD10CM/K21.9": "Esophageal reflux NOS",
+            "ICD10CM/K57.30": "Diverticular disease of colon NOS",
+            "ICD10CM/K57.32": "Diverticulitis of large intestine without perforation or abscess without bleeding",
+            "ICD10CM/N28.1": "Cyst (multiple) (solitary) of kidney (acquired)"
+        },
+        "observation with values": []
+    },
+    "day 46": {
+        "age in days": "24535",
+        "date": "2010-03-05",
+        "observation": {
+            "ATC/R03AC02": "salbutamol",
+            "ATC/R03AK01": "epinephrine and other drugs for obstructive airway diseases",
+            "ATC/R03AK02": "isoprenaline and other drugs for obstructive airway diseases",
+            "ATC/R03AK04": "salbutamol and sodium cromoglicate",
+            "ATC/R03AK13": "salbutamol and beclometasone",
+            "ATC/R03AL02": "salbutamol and ipratropium bromide",
+            "ATC/R03CC02": "NO_DEF",
+            "ATC/R03DA54": "theophylline, combinations excl. psycholeptics"
+        },
+        "observation with values": []
+    },
+    "day 47": {
+        "age in days": "24551",
+        "date": "2010-03-21",
+        "observation": {
+            "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+            "ICD10CM/F06.0": "Organic hallucinatory state (nonalcoholic)",
+            "ICD10CM/I50.814": "Right heart failure due to left heart failure",
+            "ICD10CM/N95.2": "Senile (atrophic) vaginitis",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 48": {
+        "age in days": "24595",
+        "date": "2010-05-04",
+        "observation": {
+            "CPT4/99213": "OFFICE OUTPATIENT VISIT 15 MINUTES",
+            "ICD10CM/J30.0": "NO_DEF",
+            "ICD10CM/K21.9": "Esophageal reflux NOS",
+            "ICD10CM/M15.9": "Generalized osteoarthritis NOS",
+            "ICD10CM/M19.249": "Secondary osteoarthritis, unspecified hand",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 49": {
+        "age in days": "24600",
+        "date": "2010-05-09",
+        "observation": {
+            "ATC/C03AX01": "hydrochlorothiazide, combinations",
+            "ATC/C09AA03": "NO_DEF",
+            "ATC/C09BA03": "lisinopril and diuretics",
+            "ATC/C09BB03": "lisinopril and amlodipine",
+            "ATC/C10BX07": "rosuvastatin, amlodipine and lisinopril"
+        },
+        "observation with values": []
+    },
+    "day 5": {
+        "age in days": "24084",
+        "date": "2008-12-09",
+        "observation": {
+            "CPT4/99284": "EMERGENCY DEPARTMENT VISIT HIGH/URGENT SEVERITY",
+            "ICD10CM/J45.909": "Unspecified asthma, uncomplicated",
+            "ICD10CM/S01.00XA": "Unspecified open wound of scalp, initial encounter",
+            "ICD10CM/S01.512A": "Laceration without foreign body of oral cavity, initial encounter"
+        },
+        "observation with values": []
+    },
+    "day 50": {
+        "age in days": "24619",
+        "date": "2010-05-28",
+        "observation": {
+            "ATC/C01DA58": "isosorbide dinitrate, combinations",
+            "ATC/C02AA52": "reserpine, combinations",
+            "ATC/C02DB02": "NO_DEF",
+            "ATC/C02LG02": "hydralazine and diuretics",
+            "ATC/C03AX01": "hydrochlorothiazide, combinations"
+        },
+        "observation with values": []
+    },
+    "day 51": {
+        "age in days": "24620",
+        "date": "2010-05-29",
+        "observation": {
+            "CPT4/4048F": "DOC ANTIBIO GIVEN W/IN 1 HR PRIOR SURG/INCIS",
+            "CPT4/99223": "INITIAL HOSPITAL CARE/DAY 70 MINUTES",
+            "ICD10CM/G89.18": "Postoperative pain NOS",
+            "ICD10CM/K57.32": "Diverticulitis of large intestine without perforation or abscess without bleeding",
+            "ICD10CM/K57.33": "Diverticulitis of large intestine without perforation or abscess with bleeding",
+            "ICD10CM/L26": "Hebra's pityriasis"
+        },
+        "observation with values": []
+    },
+    "day 52": {
+        "age in days": "24634",
+        "date": "2010-06-12",
+        "observation": {
+            "ATC/A01AA51": "sodium fluoride, combinations",
+            "ATC/A02AF01": "magaldrate and antiflatulents",
+            "ATC/A02AF02": "ordinary salt combinations and antiflatulents",
+            "ATC/A06AB57": "cascara, combinations",
+            "ATC/A07BA01": "medicinal charcoal",
+            "ATC/A07BA51": "medicinal charcoal, combinations",
+            "ATC/A07FA51": "lactic acid producing organisms, combinations",
+            "ATC/A12CD51": "fluoride, combinations",
+            "ATC/C01DA52": "glyceryl trinitrate, combinations",
+            "ATC/G04BE52": "papaverine, combinations"
+        },
+        "observation with values": []
+    },
+    "day 53": {
+        "age in days": "24640",
+        "date": "2010-06-18",
+        "observation": {
+            "CPT4/82310": "CALCIUM TOTAL",
+            "CPT4/86803": "HEPATITIS C ANTIBODY",
+            "ICD10CM/D63.1": "Erythropoietin resistant anemia (EPO resistant anemia)",
+            "ICD10CM/E11.29": "Type 2 diabetes mellitus with renal tubular degeneration",
+            "ICD10CM/E83.50": "Unspecified disorder of calcium metabolism",
+            "ICD10CM/I13.0": "Hypertensive heart and chronic kidney disease with heart failure and stage 1 through stage 4 chronic kidney disease, or unspecified chronic kidney disease",
+            "ICD10CM/N18.6": "Chronic kidney disease requiring chronic dialysis"
+        },
+        "observation with values": []
+    },
+    "day 54": {
+        "age in days": "24648",
+        "date": "2010-06-26",
+        "observation": {
+            "ICD10CM/E46": "Protein-calorie imbalance NOS",
+            "ICD10CM/G60.9": "NO_DEF",
+            "ICD10CM/I47.2": "NO_DEF",
+            "ICD10CM/R33.9": "Retention of urine, unspecified",
+            "ICD10CM/W19.XXXA": "Unspecified fall, initial encounter",
+            "ICD10CM/Z90.710": "Acquired absence of uterus NOS",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": [
+            "Visit/IP-5.0"
+        ]
+    },
+    "day 55": {
+        "age in days": "24686",
+        "date": "2010-08-03",
+        "observation": {
+            "CPT4/36415": "COLLECTION VENOUS BLOOD VENIPUNCTURE",
+            "CPT4/80051": "ELECTROLYTE PANEL",
+            "CPT4/85610": "PROTHROMBIN TIME",
+            "ICD10CM/R94.4": "Abnormal renal function test",
+            "ICD10CM/Z79.01": "Long term (current) use of anticoagulants",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 56": {
+        "age in days": "24700",
+        "date": "2010-08-17",
+        "observation": {
+            "ATC/C10AB05": "NO_DEF",
+            "ATC/C10BA03": "pravastatin and fenofibrate",
+            "ATC/C10BA04": "simvastatin and fenofibrate"
+        },
+        "observation with values": []
+    },
+    "day 57": {
+        "age in days": "24713",
+        "date": "2010-08-30",
+        "observation": {
+            "CPT4/99233": "SBSQ HOSPITAL CARE/DAY 35 MINUTES",
+            "ICD10CM/N18.6": "Chronic kidney disease requiring chronic dialysis",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 58": {
+        "age in days": "24752",
+        "date": "2010-10-08",
+        "observation": {
+            "ATC/A04AD54": "chlorobutanol, combinations",
+            "ATC/A08AA56": "ephedrine, combinations",
+            "ATC/B03BA51": "cyanocobalamin, combinations",
+            "ATC/C01AB51": "proscillaridin, combinations",
+            "ATC/C01BA51": "quinidine, combinations excl. psycholeptics",
+            "ATC/C01DA52": "glyceryl trinitrate, combinations",
+            "ATC/C01DA55": "pentaerithrityl tetranitrate, combinations",
+            "ATC/C02AA52": "reserpine, combinations",
+            "ATC/C05BB56": "glucose, combinations",
+            "ATC/C05CA51": "rutoside, combinations",
+            "ATC/C10AD52": "nicotinic acid, combinations",
+            "ATC/G04BE52": "papaverine, combinations",
+            "ATC/J01CA51": "ampicillin, combinations",
+            "ATC/N01BA52": "procaine, combinations",
+            "ATC/N02AA59": "codeine, combinations excl. psycholeptics",
+            "ATC/N02BA57": "ethenzamide, combinations excl. psycholeptics",
+            "ATC/N02BB51": "phenazone, combinations excl. psycholeptics",
+            "ATC/N02BB52": "metamizole sodium, combinations excl. psycholeptics",
+            "ATC/N05BB51": "hydroxyzine, combinations",
+            "ATC/N05BC51": "NO_DEF",
+            "ATC/N05CX01": "meprobamate, combinations",
+            "ATC/N05CX02": "methaqualone, combinations",
+            "ATC/R01BA52": "pseudoephedrine, combinations",
+            "ATC/R01BA53": "NO_DEF",
+            "ATC/R03AK01": "epinephrine and other drugs for obstructive airway diseases",
+            "ATC/R03AK02": "isoprenaline and other drugs for obstructive airway diseases",
+            "ATC/R03CB51": "isoprenaline, combinations",
+            "ATC/R03CC53": "terbutaline, combinations",
+            "ATC/R03DA04": "NO_DEF",
+            "ATC/R03DA20": "combinations of xanthines",
+            "ATC/R03DA51": "diprophylline, combinations",
+            "ATC/R03DA54": "theophylline, combinations excl. psycholeptics",
+            "ATC/R03DA57": "theobromine, combinations",
+            "ATC/R03DA74": "theophylline, combinations with psycholeptics",
+            "ATC/R03DB04": "theophylline and adrenergics",
+            "ATC/R06AA52": "diphenhydramine, combinations",
+            "ATC/R06AA59": "doxylamine, combinations",
+            "ATC/R07AB52": "nikethamide, combinations"
+        },
+        "observation with values": []
+    },
+    "day 59": {
+        "age in days": "24776",
+        "date": "2010-11-01",
+        "observation": {
+            "ATC/A06AA51": "liquid paraffin, combinations",
+            "ATC/B01AB51": "heparin, combinations",
+            "ATC/B05BC02": "NO_DEF",
+            "ATC/C05BA53": "NO_DEF",
+            "ATC/C05BB56": "glucose, combinations",
+            "ATC/C10AD52": "nicotinic acid, combinations",
+            "ATC/D01AC60": "bifonazole, combinations",
+            "ATC/D02AE01": "NO_DEF",
+            "ATC/D02AE51": "carbamide, combinations",
+            "ATC/D05AC51": "dithranol, combinations",
+            "ATC/D07XA01": "NO_DEF",
+            "ATC/D07XB02": "NO_DEF",
+            "ATC/D07XB05": "NO_DEF",
+            "ATC/D08AJ58": "benzethonium chloride, combinations",
+            "ATC/D10AD51": "tretinoin, combinations",
+            "ATC/G03CA53": "estradiol, combinations",
+            "ATC/N01BB52": "lidocaine, combinations",
+            "ATC/R03DA54": "theophylline, combinations excl. psycholeptics",
+            "ATC/R03DA57": "theobromine, combinations"
+        },
+        "observation with values": []
+    },
+    "day 6": {
+        "age in days": "24111",
+        "date": "2009-01-05",
+        "observation": {
+            "CPT4/85025": "Automated platelet count",
+            "CPT4/88305": "LEVEL IV SURG PATHOLOGY GROSS&MICROSCOPIC EXAM",
+            "ICD10CM/C34.80": "Malignant neoplasm of overlapping sites of unspecified bronchus and lung",
+            "None/No matching concept": "NO_DEF"
+        },
+        "observation with values": []
+    },
+    "day 7": {
+        "age in days": "24113",
+        "date": "2009-01-07",
+        "observation": {
+            "ATC/N02BA51": "acetylsalicylic acid, combinations excl. psycholeptics",
+            "ATC/N02BE51": "paracetamol, combinations excl. psycholeptics",
+            "ATC/N04BA01": "NO_DEF",
+            "ATC/N04BA02": "levodopa and decarboxylase inhibitor",
+            "ATC/N04BA03": "levodopa, decarboxylase inhibitor and COMT inhibitor",
+            "ATC/N04BA05": "melevodopa and decarboxylase inhibitor",
+            "ATC/N04BA06": "etilevodopa and decarboxylase inhibitor"
+        },
+        "observation with values": []
+    },
+    "day 8": {
+        "age in days": "24118",
+        "date": "2009-01-12",
+        "observation": {
+            "ATC/N02BA51": "acetylsalicylic acid, combinations excl. psycholeptics",
+            "ATC/N02BE51": "paracetamol, combinations excl. psycholeptics",
+            "ATC/N04BA01": "NO_DEF",
+            "ATC/N04BA02": "levodopa and decarboxylase inhibitor",
+            "ATC/N04BA03": "levodopa, decarboxylase inhibitor and COMT inhibitor",
+            "ATC/N04BA05": "melevodopa and decarboxylase inhibitor",
+            "ATC/N04BA06": "etilevodopa and decarboxylase inhibitor"
+        },
+        "observation with values": []
+    },
+    "day 9": {
+        "age in days": "24119",
+        "date": "2009-01-13",
+        "observation": {
+            "CPT4/00120": "Anesthesia for procedure on inner ear",
+            "ICD10CM/Z48.03": "Encounter for change or removal of drains",
+            "ICD10CM/Z79.4": "Long term (current) use of insulin"
+        },
+        "observation with values": []
+    }
+}


### PR DESCRIPTION
Implementation for issue #24. 

For each code, we look up its text description in MRCONSO.RRF (STR column). Since there might be multiple entries for the same code, we only keep the shortest string (with at least 4 characters) that satisfy the query condition: `"SUPPRESS" NOT IN ('O', 'Y') AND ISPREF='Y' AND LAT='ENG'`. For code with no description, they are mapped to `NO_DEF`. The mapping is stored as an `OntologyCodeDictionary` in `ontology.db`.

`create_timelines.py` shows an example of how to query per-patient timeline object with text descriptions. 

`test_patient.json` shows an example output from a SynPUF patient.